### PR TITLE
Handle track artist links in track results and compilation album pages

### DIFF
--- a/app/routes/music/album/album.handlebars
+++ b/app/routes/music/album/album.handlebars
@@ -60,7 +60,9 @@
       <div class="col-sm-4">
         <span class="track_title {{#if (isExplicit this)}}explicit{{/if}} {{#if (isRecommended this)}}recommended{{/if}}">{{title}}</span>
       </div>
-      <div class="col-sm-3">{{track_artist.name}}</div>
+      <div class="col-sm-3">
+        <a href="/music/artist/{{getArtistKeyProp track_artist}}" title="{{track_artist.name}}">{{track_artist.name}}</a>
+      </div>
     {{else}}
       <div class="col-sm-7">
         <span class="track_title {{#if (isExplicit this)}}explicit{{/if}} {{#if (isRecommended this)}}recommended{{/if}}">{{title}}</span> 

--- a/app/services/artist.service.js
+++ b/app/services/artist.service.js
@@ -33,7 +33,11 @@ function getKeyValue(artist) {
     const key =
       artist.key || artist[datastore.KEY] || artist.entityKey || artist.__key;
 
-    return key.id || `${key.name}-${key.parent.id}`;
+    if(key) {
+      return key.id || `${key.name}-${key.parent.id}`;
+    } else {
+      console.error(`No key in ${JSON.stringify(artist)}`);
+    }
   }
 
   return "";

--- a/app/views/partials/search/track.results.handlebars
+++ b/app/views/partials/search/track.results.handlebars
@@ -12,17 +12,24 @@
     {{/if}}
     {{#each results.hits}}
         <div class="row mx-0 border-top py-2">
-            <div class="col-sm-1 search_result__col no_overflow">
+            <div class="col-sm-1 search_result__col no_overflow">                                
                 <a href="/music/album/{{_source.album.album_id.value}}" title="{{displayAlbumTitle _source.album}}">
                     <img src="{{_source.album.lastfm_med_image_url}}">
                 </a>
             </div>
             <div class="col-sm-3 search_result__col">
-                <a href="/music/artist/{{getTrackArtistKey _source}}" title="{{displayAlbumOrTrackArtist _source}}">{{displayAlbumOrTrackArtist _source}}</a>
+                {{#if _source.album.is_compilation}}
+                    {{displayAlbumOrTrackArtist _source}}                    
+                {{else}}
+                    <a href="/music/artist/{{getTrackArtistKey _source}}" title="{{displayAlbumOrTrackArtist _source}}">{{displayAlbumOrTrackArtist _source}}</a>
+                {{/if}}
             </div>
             <div class="col-sm-3 search_result__col">
                 <a href="/music/album/{{_source.album.album_id.value}}" title="{{displayAlbumTitle _source.album}}">{{displayAlbumTitle _source.album}}</a>
                 <ul class="list-inline">
+                    {{#if _source.album.is_compilation}}
+                    <li class="badge badge-info">Compilation</li>
+                    {{/if}}
                     {{#each _source.album.current_tags}}
                     <li class="list-inline-item badge badge-secondary">{{formatTag this}}</li>
                     {{/each}}


### PR DESCRIPTION
### What changed?

- Add a null check for the artist key and log the error instead of failing
- Avoid linking artist names for compilation tracks in search results for now (linking would require another track re-index for compilation tracks)
- Include artist links on the compilation album page
- Add a "Compilation" badge in the track results from search