### PR TITLE
Update automatic scaling settings

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -11,4 +11,4 @@ handlers:
 automatic_scaling:
   max_instances: 2
   max_idle_instances: 1
-  min_pending_latency: 500
+  min_pending_latency: 500ms

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -8,7 +8,7 @@ handlers:
     secure: always
     redirect_http_response_code: 301
     script: auto
-instance_class: B1
-basic_scaling:
+automatic_scaling:
   max_instances: 2
-  idle_timeout: 5m
+  max_idle_instances: 1
+  min_pending_latency: 500

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -8,3 +8,7 @@ handlers:
     secure: always
     redirect_http_response_code: 301
     script: auto
+instance_class: B1
+basic_scaling:
+  max_instances: 2
+  idle_timeout: 5m


### PR DESCRIPTION
# What changed?
Updated the automatic scaling settings to limit the number of active instances to two and create new instances only when a request is waiting more than 500ms for a response.