### PR TITLE
Rotation tags on crate items

### DIFF
--- a/client/src/components/crates/AddCrateItemModal.vue
+++ b/client/src/components/crates/AddCrateItemModal.vue
@@ -1,0 +1,192 @@
+<template>
+  <div ref="modal" class="modal">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Add your own item</h5>
+          <button
+            type="button"
+            class="btn-close"
+            @click="hide"
+            aria-label="Close"
+          ></button>
+        </div>
+        <div class="modal-body">
+          <p class="text-muted">
+            Add something to your crate that's not in the CHIRP library
+          </p>
+          <form>
+            <div class="row mb-3">
+              <label for="artist" class="col-2 col-form-label">Artist</label>
+              <div class="col-10">
+                <input id="artist" class="form-control" v-model="item.artist" />
+              </div>
+            </div>
+            <div class="row mb-3">
+              <label for="track" class="col-2 col-form-label">Track</label>
+              <div class="col-10">
+                <input id="track" class="form-control" v-model="item.track" />
+              </div>
+            </div>
+            <div class="row mb-3">
+              <label for="album" class="col-2 col-form-label">Album</label>
+              <div class="col-10">
+                <input id="album" class="form-control" v-model="item.album" />
+              </div>
+            </div>
+            <div class="row mb-3">
+              <label for="label" class="col-2 col-form-label">Label</label>
+              <div class="col-10">
+                <input id="label" class="form-control" v-model="item.label" />
+              </div>
+            </div>
+            <div class="row mb-3">
+              <label class="col-2 col-form-label">Category</label>
+              <div class="col-10">
+                <div class="form-check">
+                  <input
+                    id="heavyRotation"
+                    class="form-check-input"
+                    type="checkbox"
+                    v-model="item.categories"
+                    value="heavy_rotation"
+                  />
+                  <label class="form-check-label" for="heavyRotation">
+                    Heavy Rotation
+                  </label>
+                </div>
+                <div class="form-check">
+                  <input
+                    id="lightRotation"
+                    class="form-check-input"
+                    type="checkbox"
+                    v-model="item.categories"
+                    value="light_rotation"
+                  />
+                  <label class="form-check-label" for="lightRotation">
+                    Light Rotation
+                  </label>
+                </div>
+                <div class="form-check">
+                  <input
+                    id="localClassic"
+                    class="form-check-input"
+                    type="checkbox"
+                    v-model="item.categories"
+                    value="local_classic"
+                  />
+                  <label class="form-check-label" for="localClassic">
+                    Local Classic
+                  </label>
+                </div>
+                <div class="form-check">
+                  <input
+                    id="localCurrent"
+                    class="form-check-input"
+                    type="checkbox"
+                    v-model="item.categories"
+                    value="local_current"
+                  />
+                  <label class="form-check-label" for="localCurrent">
+                    Local Current
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="row mb-3">
+              <label for="notes" class="col-2 col-form-label">Notes</label>
+              <div class="col-10">
+                <input id="notes" class="form-control" v-model="item.notes" />
+              </div>
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <span v-if="error" class="text-danger">There was an error</span>
+          <button
+            v-if="!adding"
+            type="button"
+            class="btn btn-light"
+            @click="hide"
+          >
+            Cancel
+          </button>
+          <button
+            v-if="!adding"
+            type="button"
+            class="btn btn-chirp-red"
+            @click="addItem"
+          >
+            Add item
+          </button>
+          <RecordSpinner v-if="adding" class="small-spinner" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style>
+.small-spinner {
+  height: 2rem;
+}
+</style>
+
+<script>
+import Modal from "../../../node_modules/bootstrap/js/dist/modal";
+import RecordSpinner from "../../components/RecordSpinner.vue";
+
+const ADDED = "added";
+const EMPTY_ITEM = {
+  track: "",
+  artist: "",
+  album: "",
+  label: "",
+  notes: "",
+  categories: [],
+};
+
+export default {
+  components: { RecordSpinner },
+  emits: [ADDED],
+  props: {
+    crateId: String,
+  },
+  data() {
+    return {
+      modal: undefined,
+      adding: false,
+      error: false,
+      item: Object.assign({}, EMPTY_ITEM),
+    };
+  },
+  mounted() {
+    this.modal = new Modal(this.$refs.modal);
+  },
+  methods: {
+    show() {
+      this.modal.show();
+    },
+    hide() {
+      this.modal.hide();
+      this.error = false;
+      this.item = Object.assign({}, EMPTY_ITEM);
+    },
+    async addItem() {
+      this.adding = true;
+
+      try {
+        await this.$store.dispatch("addToCrate", {
+          crateId: this.crateId,
+          params: { item: this.item },
+        });
+        this.hide();
+        this.$emit(ADDED);
+      } catch (error) {
+        this.error = true;
+      }
+      this.adding = false;
+    },
+  },
+};
+</script>

--- a/client/src/views/crates/Crate.vue
+++ b/client/src/views/crates/Crate.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="container" class="px-0">
-    <div class="d-flex mb-3 py-2 px-2 bg-white align-items-center">
+    <div class="d-flex mb-3 py-2 px-3 bg-white align-items-center">
       <div class="d-flex align-items-center flex-grow-1">
         <EditableHeading
           v-if="crate"
@@ -62,7 +62,18 @@
         </li>
       </template>
     </draggable>
-    <div v-if="!showList && !loading">This crate is empty</div>
+    <div v-if="!showList && !loading" class="ps-3">This crate is empty</div>
+    <div class="row g-2 mt-1 pt-1 border-top">
+      <div class="col-12 ps-4">
+        <button
+          v-if="!loading"
+          class="btn btn-outline-chirp-red"
+          @click="showAddModal"
+        >
+          Add your own item
+        </button>
+      </div>
+    </div>
     <RecordSpinner v-if="loading" />
     <AddCrateItemModal :crateId="id" ref="addModal" @added="scrollToBottom" />
 

--- a/client/src/views/crates/Crate.vue
+++ b/client/src/views/crates/Crate.vue
@@ -64,6 +64,7 @@
     </draggable>
     <div v-if="!showList && !loading">This crate is empty</div>
     <RecordSpinner v-if="loading" />
+    <AddCrateItemModal :crateId="id" ref="addModal" @added="scrollToBottom" />
 
     <div id="deleteModal" class="modal">
       <div class="modal-dialog">
@@ -99,128 +100,6 @@
         </div>
       </div>
     </div>
-
-    <div id="addModal" class="modal">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">Add your own item</h5>
-            <button
-              type="button"
-              class="btn-close"
-              @click="hideAddModal"
-              aria-label="Close"
-            ></button>
-          </div>
-          <div class="modal-body">
-            <p class="text-muted">
-              Add something to your crate that's not in the CHIRP library
-            </p>
-            <form>
-              <div class="row mb-3">
-                <label for="artist" class="col-2 col-form-label">Artist</label>
-                <div class="col-10">
-                  <input
-                    id="artist"
-                    class="form-control"
-                    v-model="item.artist"
-                  />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <label for="track" class="col-2 col-form-label">Track</label>
-                <div class="col-10">
-                  <input id="track" class="form-control" v-model="item.track" />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <label for="album" class="col-2 col-form-label">Album</label>
-                <div class="col-10">
-                  <input id="album" class="form-control" v-model="item.album" />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <label for="label" class="col-2 col-form-label">Label</label>
-                <div class="col-10">
-                  <input id="label" class="form-control" v-model="item.label" />
-                </div>
-              </div>
-              <div class="row mb-3">
-                <label class="col-2 col-form-label">Category</label>
-                <div class="col-10">
-                  <div class="form-check">
-                    <input
-                      class="form-check-input"
-                      type="radio"
-                      name="localRadios"
-                      id="localNone"
-                      v-model="item.category"
-                      value=""
-                      checked
-                    />
-                    <label class="form-check-label" for="localRadios">
-                      None
-                    </label>
-                  </div>
-                  <div class="form-check">
-                    <input
-                      class="form-check-input"
-                      type="radio"
-                      name="localRadios"
-                      id="localClassic"
-                      v-model="item.category"
-                      value="local_classic"
-                    />
-                    <label class="form-check-label" for="localRadios">
-                      Local Classic
-                    </label>
-                  </div>
-                  <div class="form-check">
-                    <input
-                      class="form-check-input"
-                      type="radio"
-                      name="localRadios"
-                      id="localCurrent"
-                      v-model="item.category"
-                      value="local_current"
-                    />
-                    <label class="form-check-label" for="localRadios">
-                      Local Current
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <label for="notes" class="col-2 col-form-label">Notes</label>
-                <div class="col-10">
-                  <input id="notes" class="form-control" v-model="item.notes" />
-                </div>
-              </div>
-            </form>
-          </div>
-          <div class="modal-footer">
-            <span v-if="addError" class="text-danger">There was an error</span>
-            <button
-              v-if="!adding"
-              type="button"
-              class="btn btn-light"
-              @click="hideAddModal"
-            >
-              Cancel
-            </button>
-            <button
-              v-if="!adding"
-              type="button"
-              class="btn btn-chirp-red"
-              @click="addItem"
-            >
-              Add item
-            </button>
-            <RecordSpinner v-if="adding" class="small-spinner" />
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -244,10 +123,6 @@
   cursor: move;
 }
 
-.small-spinner {
-  height: 2rem;
-}
-
 .sortable-ghost {
   background-color: var(--bright-red);
   padding-top: 1rem;
@@ -265,9 +140,10 @@ import AlbumItem from "../../components/crates/AlbumItem";
 import ArtistItem from "../../components/crates/ArtistItem";
 import CrateItem from "../../components/crates/CrateItem";
 import TrackItem from "../../components/crates/TrackItem";
+import AddCrateItemModal from "../../components/crates/AddCrateItemModal.vue";
 import updateTitle from "../../mixins/updateTitle";
 
-let deleteModal, addModal;
+let deleteModal;
 
 export default {
   name: "Crate",
@@ -280,6 +156,7 @@ export default {
     ArtistItem,
     CrateItem,
     TrackItem,
+    AddCrateItemModal,
   },
   props: {
     id: String,
@@ -287,16 +164,6 @@ export default {
   data() {
     return {
       loading: false,
-      adding: false,
-      addError: false,
-      item: {
-        track: "",
-        artist: "",
-        album: "",
-        label: "",
-        notes: "",
-        category: "",
-      },
     };
   },
   computed: {
@@ -333,7 +200,6 @@ export default {
   },
   mounted() {
     deleteModal = new Modal(document.getElementById("deleteModal"));
-    addModal = new Modal(document.getElementById("addModal"));
   },
   mixins: [updateTitle],
   methods: {
@@ -369,19 +235,7 @@ export default {
       deleteModal.hide();
     },
     showAddModal() {
-      addModal.show();
-    },
-    hideAddModal() {
-      addModal.hide();
-      this.addError = false;
-      this.item = {
-        track: "",
-        artist: "",
-        album: "",
-        label: "",
-        notes: "",
-        category: "",
-      };
+      this.$refs.addModal.show();
     },
     deleteCrate() {
       this.hideDeleteModal();
@@ -391,27 +245,6 @@ export default {
     scrollToBottom() {
       const el = document.scrollingElement;
       el.scrollTo(0, el.scrollHeight);
-    },
-    async addItem() {
-      this.adding = true;
-
-      try {
-        const newItem = { ...this.item };
-        if (newItem.category !== "") {
-          newItem.categories = [newItem.category];
-        }
-        delete newItem.category;
-
-        await this.$store.dispatch("addToCrate", {
-          crateId: this.id,
-          params: { item: newItem },
-        });
-        this.hideAddModal();
-      } catch (error) {
-        this.addError = true;
-      }
-      this.scrollToBottom();
-      this.adding = false;
     },
     async renameCrate(event) {
       this.$store.dispatch("renameCrate", {

--- a/client/src/views/crates/Crate.vue
+++ b/client/src/views/crates/Crate.vue
@@ -37,8 +37,8 @@
       <template #item="{ element, index }">
         <li class="list-group-item">
           <div class="row g-2">
-            <div class="handle col-auto">
-              <font-awesome-icon icon="grip-lines" size="md" />
+            <div class="crate_item__handle col-auto">
+              <font-awesome-icon icon="grip-lines" />
             </div>
             <div class="col-1 me-2 text-end numeral crate_item__duration">
               <TrackDuration v-if="element.track" :track="element.track" />
@@ -103,7 +103,7 @@
   </div>
 </template>
 
-<style scoped>
+<style>
 @media (max-width: 576px) {
   .crate_item__duration,
   .crate_item__details {
@@ -119,7 +119,7 @@
   }
 }
 
-.handle {
+.crate_item__handle {
   cursor: move;
 }
 

--- a/client/src/views/crates/Crate.vue
+++ b/client/src/views/crates/Crate.vue
@@ -32,7 +32,7 @@
       @change="onMove"
       tag="ol"
       class="list-group list-group-flush"
-      handle=".handle"
+      handle=".crate_item__handle"
     >
       <template #item="{ element, index }">
         <li class="list-group-item">


### PR DESCRIPTION
* Adds heavy and light rotation tags as options when adding your own crate item
* Adds another "add item" button at the bottom of the list. Since the header is no longer sticky to make dragging up more intuitive, that button could get lost in a long crate. I kept it in the header, too, since in a long crate someone might not want to scroll to the bottom before adding their item.
* Moves the add modal into a separate component as code clean up
* Removes a bad and unnecessary size value on the drag icon that was throwing warnings in the console