### PR TITLE
Fix rotation play report

### DIFF
--- a/client/src/stores/reports.js
+++ b/client/src/stores/reports.js
@@ -1,0 +1,19 @@
+import { defineStore } from "pinia";
+import api from "../services/api.service";
+
+export const useReportsStore = defineStore("reports", {
+  state: () => ({
+    rotationPlays: {
+      plays: [],
+      start: undefined,
+      end: undefined,
+    },
+  }),
+  actions: {
+    async getRotationPlays({ start, end } = {}) {
+      if (this.rotationPlays.start !== start || this.rotationPlays.end !== end) {
+        this.rotationPlays = await api.getRotationPlays({ start, end });
+      }
+    },
+  },
+});

--- a/client/src/views/reports/RotationPlays.vue
+++ b/client/src/views/reports/RotationPlays.vue
@@ -70,7 +70,7 @@ import RecordSpinner from "@/components/RecordSpinner.vue";
 import RotationPlayRow from "@/components/reports/RotationPlayRow.vue";
 import { mapStores } from "pinia";
 import { useAlbumsStore } from "@/stores/albums";
-import { usePlaylistStore } from "@/stores/playlist";
+import { useReportsStore } from "@/stores/reports";
 
 function sortByPlayCountThenLocal(a, b) {
   // sort by play count first
@@ -112,7 +112,7 @@ export default {
     };
   },
   computed: {
-    ...mapStores(useAlbumsStore, usePlaylistStore),
+    ...mapStores(useAlbumsStore, useReportsStore),
     htmlFrom: {
       /*
         get a value that the date input will accept
@@ -162,7 +162,7 @@ export default {
       },
     },
     rotationPlays() {
-      const plays = this.albumsStore.rotationPlays;
+      const plays = this.reportsStore.rotationPlays.plays;
       const albums = [
         ...this.albumsStore.taggedAlbums("heavy_rotation"),
         ...this.albumsStore.taggedAlbums("light_rotation"),
@@ -201,7 +201,7 @@ export default {
       this.loading = true;
       await Promise.all([
         this.loadAllTaggedAlbums(),
-        this.playlistStore.getRotationPlays({
+        this.reportsStore.getRotationPlays({
           start: this.from.getTime(),
           end: this.to.getTime(),
         }),


### PR DESCRIPTION
This completes the transition from VueX to Pinia. It also splits the data into a separate reports store in advance of the playlist store also tracking rotation plays on a much shorter time scale.