### PR TITLE
Don't fetch crates if request already in progress

### DIFF
--- a/client/src/components/AddToCrate.vue
+++ b/client/src/components/AddToCrate.vue
@@ -68,7 +68,7 @@ export default {
     },
   },
   async created() {
-    if (this.cratesStore.crates.length === 0) {
+    if (this.cratesStore.crates.length === 0 && !this.cratesStore.loadingCrates) {
       await this.cratesStore.getCrates();
     }
   },


### PR DESCRIPTION
In the search view, the client will call the /crate api route for every instance of the "add to crate" button on page load. Let's change it so we only call the api route if there isn't already a request in progress 


Network log before change, for reference 
<img width="789" alt="Screen Shot 2022-12-30 at 2 32 05 PM" src="https://user-images.githubusercontent.com/6528140/210109785-ad16ffa6-5ad8-459f-9470-abb9b4fc8548.png">
