### PR TITLE
Edit tags for a single album

### DIFF
--- a/app/routes/api/album/controller.js
+++ b/app/routes/api/album/controller.js
@@ -63,4 +63,15 @@ module.exports = {
       next(error);
     }
   },
+  async updateAlbumTags(req, res, next) {
+    try {
+      const album = await AlbumService.getAlbumById(
+        req.params.album_id
+      )
+      await AlbumService.updateCurrentTags(album, req.body.tags, req.user)
+      res.json(album.plain({showKey: true}))
+    } catch (error) {
+      next(error);
+    }
+  }
 };

--- a/app/routes/api/album/router.js
+++ b/app/routes/api/album/router.js
@@ -38,4 +38,11 @@ router.patch(
   controller.updateTrack
 );
 
+router.patch(
+  "/:album_id",
+  validateTags,
+  checkErrors,
+  controller.updateAlbumTags
+)
+
 module.exports = router;

--- a/app/services/album.service.js
+++ b/app/services/album.service.js
@@ -1,5 +1,5 @@
-const { Album, Document, Track } = require("../models");
-const { datastore, renameKey } = require("../db");
+const { Album, Document, Track, TagEdit } = require("../models");
+const { datastore, gstore, renameKey } = require("../db");
 const LastFm = require("lastfm-node-client");
 const lastFm = new LastFm(process.env.LASTFM_API_KEY);
 
@@ -94,6 +94,25 @@ async function addImagesFromLastFm(album) {
       console.error(err);
     }
   }
+}
+
+async function updateCurrentTags(album, tags, user) {
+  const transaction = gstore.transaction();
+  await transaction.run();
+
+  const oldTags = [...album.current_tags];
+  album.current_tags = tags;
+  await album.save();
+
+  const edit = new TagEdit({
+    added: tags,
+    removed: oldTags,
+    author: user.entityKey,
+    subject: album.entityKey,
+  });
+  await edit.save();
+
+  await transaction.commit();
 }
 
 async function listAlbumComments(album) {
@@ -231,6 +250,7 @@ module.exports = {
   listAlbumReviews,
   listAlbumTracks,
   options,
+  updateCurrentTags,
   getAlbumsByAlbumArtist,
   getAlbumsWithTag,
   getAlbumsImportedSince,

--- a/client/src/components/crates/AlbumItem.vue
+++ b/client/src/components/crates/AlbumItem.vue
@@ -8,7 +8,7 @@
       />
       <CrateAlbumSpans :album="element.album" />
     </div>
-    <TagList :tags="element.album.current_tags" />
+    <TagList :tags="element.album.current_tags" :album="element.album" />
     <div class="text-muted">{{ element.notes }}</div>
   </div>
 </template>

--- a/client/src/components/music/AlbumCard.vue
+++ b/client/src/components/music/AlbumCard.vue
@@ -23,7 +23,7 @@
         {{ album.label }} &middot; {{ album.year }}
         <span v-if="album.disc_number">– Disc {{ album.disc_number }}</span>
       </p>
-      <TagList :tags="album.current_tags" />
+      <TagList :tags="album.current_tags" :album="album"/>
     </div>
     <ReviewPreview v-if="showReview" class="w-100" :album="album" />
   </article>

--- a/client/src/components/music/EditTagsButton.vue
+++ b/client/src/components/music/EditTagsButton.vue
@@ -1,17 +1,28 @@
 <template>
-  <li class="list-inline-item" @click="show">
+  <li class="list-inline-item edit-tags-button" @click="show">
     <div class="fw-normal text-body badge rounded-pill border">
-      <font-awesome-icon class="opacity-50 pr-1" icon="plus" size="sm" />
-      <span class="opacity-75">Add Tag</span>
+      <font-awesome-icon class="opacity-50 pr-2" icon="edit" size="sm" />
+      <span class="opacity-75">Edit Tags</span>
     </div>
   </li>
-  <Modal title="Edit tags" ref="modal" @confirm="setAlbumTags">
-    <h2>{{ albumTitle }}</h2>
-
+  <Modal title="Edit tags" ref="modal" @confirm="setAlbumTags" confirm-label="Update Tags">
+    <h3> {{ albumTitle }}</h3>
+    <h4>by {{ album.album_artist.name  }}</h4>
     <ul>
       <li v-for="tag in allowedTags" :key="tag">
-        <input type="checkbox" :name="tag" :value="tag" v-model="selectedTags[tag]" />
-        <Tag :tag="tag" @click="selectedTags[tag] = !selectedTags[tag]"/>
+        <input
+          class="mr-2"
+          type="checkbox"
+          :name="tag"
+          :value="tag"
+          v-model="selectedTags[tag]"
+        />
+        <Tag
+          class="selectable-tag"
+          :class="{ selected: selectedTags[tag] }"
+          :tag="tag"
+          @click="selectedTags[tag] = !selectedTags[tag]"
+        />
       </li>
     </ul>
   </Modal>
@@ -32,7 +43,7 @@ const allowedTags = [
 ];
 
 export default {
-  name: "NewTagButton",
+  name: "EditTagsButton",
   props: {
     currentTags: {
       type: Array,
@@ -45,7 +56,6 @@ export default {
   components: { Modal, Tag },
   data() {
     return {
-      isNewTagPopupOpen: false,
       allowedTags,
       selectedTags: allowedTags.reduce((tagsObject, tag) => {
         return {
@@ -72,12 +82,38 @@ export default {
       this.$refs.modal.show();
     },
     setAlbumTags() {
-      let tags = allowedTags.filter(tag => this.selectedTags[tag])
+      let tags = allowedTags.filter((tag) => this.selectedTags[tag]);
       this.albumsStore.updateAlbumTags({
         album: this.album,
         tags,
       });
-    }
+      this.$refs.modal.hide();
+    },
   },
 };
 </script>
+<style scoped>
+.edit-tags-button {
+  cursor: pointer;
+}
+.pr-2 {
+  padding-right: 0.25rem;
+}
+
+.mr-2 {
+  margin-right: 0.25rem;
+}
+
+ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.selectable-tag {
+  opacity: 0.6;
+}
+.selectable-tag:hover,
+.selectable-tag.selected {
+  opacity: 1;
+}
+</style>

--- a/client/src/components/music/EditTagsButton.vue
+++ b/client/src/components/music/EditTagsButton.vue
@@ -7,7 +7,7 @@
   </li>
   <Modal title="Edit tags" ref="modal" @confirm="setAlbumTags" confirm-label="Update Tags">
     <h3> {{ albumTitle }}</h3>
-    <h4>by {{ album.album_artist.name  }}</h4>
+    <h4 v-if="album.album_artist">by {{ album.album_artist.name  }}</h4>
     <ul>
       <li v-for="tag in allowedTags" :key="tag">
         <input

--- a/client/src/components/music/NewTagButton.vue
+++ b/client/src/components/music/NewTagButton.vue
@@ -1,0 +1,83 @@
+<template>
+  <li class="list-inline-item" @click="show">
+    <div class="fw-normal text-body badge rounded-pill border">
+      <font-awesome-icon class="opacity-50 pr-1" icon="plus" size="sm" />
+      <span class="opacity-75">Add Tag</span>
+    </div>
+  </li>
+  <Modal title="Edit tags" ref="modal" @confirm="setAlbumTags">
+    <h2>{{ albumTitle }}</h2>
+
+    <ul>
+      <li v-for="tag in allowedTags" :key="tag">
+        <input type="checkbox" :name="tag" :value="tag" v-model="selectedTags[tag]" />
+        <Tag :tag="tag" @click="selectedTags[tag] = !selectedTags[tag]"/>
+      </li>
+    </ul>
+  </Modal>
+</template>
+
+<script>
+import Modal from "../ModalDialog.vue";
+import Tag from "./TagBadge.vue";
+
+import { mapStores } from "pinia";
+import { useAlbumsStore } from "@/stores/albums";
+
+const allowedTags = [
+  "local_current",
+  "local_classic",
+  "heavy_rotation",
+  "light_rotation",
+];
+
+export default {
+  name: "NewTagButton",
+  props: {
+    currentTags: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+    album: Object,
+  },
+  components: { Modal, Tag },
+  data() {
+    return {
+      isNewTagPopupOpen: false,
+      allowedTags,
+      selectedTags: allowedTags.reduce((tagsObject, tag) => {
+        return {
+          ...tagsObject,
+          [tag]: this.currentTags.includes(tag),
+        };
+      }, {}),
+    };
+  },
+  computed: {
+    ...mapStores(useAlbumsStore),
+    albumTitle() {
+      let title = this.album.title;
+
+      if (this.album.disc_number) {
+        title += ` (Disc ${this.album.disc_number})`;
+      }
+
+      return title;
+    },
+  },
+  methods: {
+    show() {
+      this.$refs.modal.show();
+    },
+    setAlbumTags() {
+      let tags = allowedTags.filter(tag => this.selectedTags[tag])
+      this.albumsStore.updateAlbumTags({
+        album: this.album,
+        tags,
+      });
+    }
+  },
+};
+</script>

--- a/client/src/components/music/TagList.vue
+++ b/client/src/components/music/TagList.vue
@@ -19,13 +19,10 @@
 <script>
 import Tag from "./TagBadge.vue";
 import EditTagsButton from "./EditTagsButton.vue";
+import { mapStores } from "pinia";
 
-const allowedTags = [
-  "local_current",
-  "local_classic",
-  "heavy_rotation",
-  "light_rotation",
-];
+import { useAuthStore } from "@/stores/auth";
+import { allowedTags } from "@/constants";
 
 export default {
   name: "TagList",
@@ -40,13 +37,14 @@ export default {
     album: Object,
   },
   computed: {
+    ...mapStores(useAuthStore),
     classes() {
       return {
         "d-none": this.filteredTags.length === 0,
       };
     },
     canEditTags() {
-      return !!this.album;
+      return !!this.album && this.authStore.hasRole("reviewer");
     },
     filteredTags() {
       if (!this.tags) {

--- a/client/src/components/music/TagList.vue
+++ b/client/src/components/music/TagList.vue
@@ -3,13 +3,13 @@
     <li v-for="tag in filteredTags" :key="tag" class="list-inline-item" :class="classes">
       <Tag :tag="tag" />
     </li>
-    <NewTagButton v-if="album && this.filteredTags.length < 4" :currentTags="filteredTags" :album="album" />
+    <EditTagsButton v-if="album" :currentTags="filteredTags" :album="album" />
   </ul>
 </template>
 
 <script>
 import Tag from "./TagBadge.vue";
-import NewTagButton from './NewTagButton.vue'
+import EditTagsButton from './EditTagsButton.vue'
 
 const allowedTags = [
   "local_current",
@@ -20,7 +20,7 @@ const allowedTags = [
 
 export default {
   name: "TagList",
-  components: { Tag, NewTagButton },
+  components: { Tag, EditTagsButton },
   props: {
     tags: {
       type: Array,

--- a/client/src/components/music/TagList.vue
+++ b/client/src/components/music/TagList.vue
@@ -1,15 +1,24 @@
 <template>
   <ul class="list-inline">
-    <li v-for="tag in filteredTags" :key="tag" class="list-inline-item" :class="classes">
+    <li
+      v-for="tag in filteredTags"
+      :key="tag"
+      class="list-inline-item"
+      :class="classes"
+    >
       <Tag :tag="tag" />
     </li>
-    <EditTagsButton v-if="album" :currentTags="filteredTags" :album="album" />
+    <EditTagsButton
+      v-if="canEditTags"
+      :currentTags="filteredTags"
+      :album="album"
+    />
   </ul>
 </template>
 
 <script>
 import Tag from "./TagBadge.vue";
-import EditTagsButton from './EditTagsButton.vue'
+import EditTagsButton from "./EditTagsButton.vue";
 
 const allowedTags = [
   "local_current",
@@ -35,6 +44,9 @@ export default {
       return {
         "d-none": this.filteredTags.length === 0,
       };
+    },
+    canEditTags() {
+      return !!this.album;
     },
     filteredTags() {
       if (!this.tags) {

--- a/client/src/components/music/TagList.vue
+++ b/client/src/components/music/TagList.vue
@@ -1,13 +1,15 @@
 <template>
-  <ul class="list-inline" :class="classes">
-    <li v-for="tag in filteredTags" :key="tag" class="list-inline-item">
+  <ul class="list-inline">
+    <li v-for="tag in filteredTags" :key="tag" class="list-inline-item" :class="classes">
       <Tag :tag="tag" />
     </li>
+    <NewTagButton v-if="album && this.filteredTags.length < 4" :currentTags="filteredTags" :album="album" />
   </ul>
 </template>
 
 <script>
 import Tag from "./TagBadge.vue";
+import NewTagButton from './NewTagButton.vue'
 
 const allowedTags = [
   "local_current",
@@ -18,7 +20,7 @@ const allowedTags = [
 
 export default {
   name: "TagList",
-  components: { Tag },
+  components: { Tag, NewTagButton },
   props: {
     tags: {
       type: Array,
@@ -26,6 +28,7 @@ export default {
         return [];
       },
     },
+    album: Object,
   },
   computed: {
     classes() {

--- a/client/src/components/music/search/album/AlbumResultRows.vue
+++ b/client/src/components/music/search/album/AlbumResultRows.vue
@@ -19,7 +19,7 @@
       </div>
       <div class="col-md-3 search-result__col">
         <AlbumTitleLink :album="hit._source" />
-        <TagList :tags="hit._source.current_tags" />
+        <TagList :tags="hit._source.current_tags" :album="hit._source" />
       </div>
       <AlbumLabelLink
         class="col-md-2 search-result__col"

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,0 +1,6 @@
+export const allowedTags = [
+  "local_current",
+  "local_classic",
+  "heavy_rotation",
+  "light_rotation",
+];

--- a/client/src/services/api.service.js
+++ b/client/src/services/api.service.js
@@ -73,6 +73,16 @@ export default {
     return response.data;
   },
 
+  async updateAlbumTags(album_id, tags) {
+    console.log(album_id, tags)
+    debugger;
+    const response = await instance.patch(
+      `/album/${album_id.value}`,
+      { tags }
+    )
+    return response.data
+  },
+
   async getArtist(id) {
     const getter = instance.get(`/artist/${id}`);
     return await getAndHandleError(getter);

--- a/client/src/services/api.service.js
+++ b/client/src/services/api.service.js
@@ -74,8 +74,6 @@ export default {
   },
 
   async updateAlbumTags(album_id, tags) {
-    console.log(album_id, tags)
-    debugger;
     const response = await instance.patch(
       `/album/${album_id.value}`,
       { tags }

--- a/client/src/stores/albums.js
+++ b/client/src/stores/albums.js
@@ -137,5 +137,14 @@ export const useAlbumsStore = defineStore("albums", {
         track.current_tags = oldTags;
       }
     },
+    async updateAlbumTags({ album, tags } = {}) {
+      const oldTags = album.current_tags ? [...album.current_tags] : [];
+      album.current_tags = tags;
+      try {
+        await api.updateAlbumTags(album.album_id, tags);
+      } catch (error) {
+        album.current_tags = oldTags;
+      }
+    },
   },
 });

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -33,6 +33,9 @@ export const useAuthStore = defineStore("auth", {
         return false;
       }
     },
+    hasRole: (state) => (role) => {
+      return state.user?.roles?.includes(role);
+    },
     isAuthorized: (state) => (feature) => {
       const permitted = state.features[feature];
 


### PR DESCRIPTION
Allows users to edit tags for a single album, from an AlbumTitle or an AlbumCard component. 

https://user-images.githubusercontent.com/6528140/213080928-e5cf3185-3572-4196-abe2-f6b6682adf7d.mov

This PR doesn't implement batch updates for editing multiple albums' tags at once, but that would be great to add later on. 