### PR TITLE
Edit tags only from album or tag views

### DIFF
--- a/client/src/components/AddToCrate.vue
+++ b/client/src/components/AddToCrate.vue
@@ -68,7 +68,10 @@ export default {
     },
   },
   async created() {
-    if (this.cratesStore.crates.length === 0 && !this.cratesStore.loadingCrates) {
+    if (
+      this.cratesStore.crates.length === 0 &&
+      !this.cratesStore.loadingCrates
+    ) {
       await this.cratesStore.getCrates();
     }
   },

--- a/client/src/components/music/AlbumCard.vue
+++ b/client/src/components/music/AlbumCard.vue
@@ -23,7 +23,7 @@
         {{ album.label }} &middot; {{ album.year }}
         <span v-if="album.disc_number">– Disc {{ album.disc_number }}</span>
       </p>
-      <TagList :tags="album.current_tags" :album="album"/>
+      <TagList :tags="album.current_tags" :album="album" :showEditTags="showEditTags"/>
     </div>
     <ReviewPreview v-if="showReview" class="w-100" :album="album" />
   </article>
@@ -55,6 +55,10 @@ export default {
     linkToAlbum: {
       type: Boolean,
       default: true,
+    },
+    showEditTags: {
+      type: Boolean,
+      default: false,
     },
     showReview: {
       type: Boolean,

--- a/client/src/components/music/AlbumCard.vue
+++ b/client/src/components/music/AlbumCard.vue
@@ -23,7 +23,11 @@
         {{ album.label }} &middot; {{ album.year }}
         <span v-if="album.disc_number">– Disc {{ album.disc_number }}</span>
       </p>
-      <TagList :tags="album.current_tags" :album="album" :showEditTags="showEditTags"/>
+      <TagList
+        :tags="album.current_tags"
+        :album="album"
+        :showEditTags="showEditTags"
+      />
     </div>
     <ReviewPreview v-if="showReview" class="w-100" :album="album" />
   </article>

--- a/client/src/components/music/AlbumCollection.vue
+++ b/client/src/components/music/AlbumCollection.vue
@@ -13,6 +13,7 @@
         :album="album"
         :hideArtistLink="hideArtistLinks"
         :showReview="showReview"
+        :showEditTags="true"
       />
       <button
         v-if="more && !loading"

--- a/client/src/components/music/TagList.vue
+++ b/client/src/components/music/TagList.vue
@@ -9,7 +9,7 @@
       <Tag :tag="tag" />
     </li>
     <EditTagsButton
-      v-if="canEditTags"
+      v-if="showEditTags"
       :currentTags="filteredTags"
       :album="album"
     />
@@ -35,6 +35,10 @@ export default {
       },
     },
     album: Object,
+    showEditTags: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     ...mapStores(useAuthStore),
@@ -54,6 +58,9 @@ export default {
       return this.tags
         .filter((tag) => allowedTags.includes(tag))
         .sort((a, b) => (a < b ? -1 : 1));
+    },
+    showEditTagsButton() {
+      return showEditTags && canEditTags;
     },
   },
 };

--- a/client/src/components/music/TagList.vue
+++ b/client/src/components/music/TagList.vue
@@ -60,7 +60,7 @@ export default {
         .sort((a, b) => (a < b ? -1 : 1));
     },
     showEditTagsButton() {
-      return showEditTags && canEditTags;
+      return this.showEditTags && this.canEditTags;
     },
   },
 };

--- a/client/src/services/api.service.js
+++ b/client/src/services/api.service.js
@@ -74,11 +74,8 @@ export default {
   },
 
   async updateAlbumTags(album_id, tags) {
-    const response = await instance.patch(
-      `/album/${album_id.value}`,
-      { tags }
-    )
-    return response.data
+    const response = await instance.patch(`/album/${album_id.value}`, { tags });
+    return response.data;
   },
 
   async getArtist(id) {

--- a/client/src/views/music/AlbumView.vue
+++ b/client/src/views/music/AlbumView.vue
@@ -10,6 +10,7 @@
             :linkToAlbum="false"
             :border="false"
             albumArtSrcSize="xl"
+            :showEditTags="true"
           />
         </div>
         <AddToCrate :keyToAdd="album.__key" class="col-md-4" />


### PR DESCRIPTION
Hide from search results and (most importantly) crate view to keep those views a little cleaner