### PR TITLE
Authenticate only active users

### DIFF
--- a/app/config/auth.js
+++ b/app/config/auth.js
@@ -22,7 +22,7 @@ module.exports = function configureAuth(app) {
             return done(null, false);
           }
 
-          if (user.authenticate(password)) {
+          if (user.is_active && user.authenticate(password)) {
             return done(null, user);
           } else {
             return done(null, false);


### PR DESCRIPTION
I caught a small oversight while thinking about API authentication for NIte Owl: NextUp isn't confirming that a user is still active before authenticating them 😬