### PR TITLE
List and filter on expired copy

### DIFF
--- a/app/db/migrations/README.md
+++ b/app/db/migrations/README.md
@@ -1,0 +1,1 @@
+As a NoSQL database, the Google Cloud Datastore doesn't give us the ability to run schema and data migrations as readily as a relational database. You can only load the entities and save them again with property or value changes. These scripts are intended to be run manually as part of major updates.

--- a/app/db/migrations/add-deleted-to-spotcopy.js
+++ b/app/db/migrations/add-deleted-to-spotcopy.js
@@ -1,0 +1,26 @@
+const { SpotCopy } = require("../../models");
+
+async function up() {
+  const { entities: spotCopy } = await SpotCopy.list({
+    format: "ENTITY",
+  });
+
+  const now = Date.now();
+  for (const copy of spotCopy) {    
+    if(copy.expire_on && copy.expire_on < now) {      
+      copy.deleted = true;
+    }
+    
+    try {
+      await copy.save();
+    } catch (err) {
+      console.error(err.message);
+      console.log(err.errors);
+      console.log(copy.plain());
+    } finally {
+      console.log(copy.id, copy.expire_on, copy.deleted);
+    }
+  }
+}
+
+up();

--- a/app/db/migrations/add-deleted-to-spots.js
+++ b/app/db/migrations/add-deleted-to-spots.js
@@ -1,0 +1,24 @@
+const { Spot } = require("../../models");
+
+async function up() {
+  const { entities: spots } = await Spot.list({
+    format: "ENTITY",
+  });
+
+  for (const spot of spots) {    
+    if(spot.active === false) {      
+      spot.deleted = true;      
+    }
+
+    try {
+      await spot.save();
+    } catch (err) {
+      console.error(err.message);
+      console.log(err.errors);
+      console.log(spot.plain());
+      console.log("---");
+    }
+  }
+}
+
+up();

--- a/app/db/migrations/reset-passwords.js
+++ b/app/db/migrations/reset-passwords.js
@@ -1,3 +1,7 @@
+/* 
+  Used to keep actual passwords out of the dev database
+  as part of the initial setup.
+*/
 if (process.env.DATASTORE_PROJECT_ID === "chirpradio-hrd") {
   console.error("This should never be run on the production datastore");
   process.exit(1);

--- a/app/routes/api/specification.yaml
+++ b/app/routes/api/specification.yaml
@@ -859,13 +859,6 @@ paths:
       tags:
         - Spots
       description: List all spots
-      parameters:
-        - name: active
-          in: query
-          required: false
-          default: true
-          schema:
-            type: boolean
       responses:
         '200':
           description: Success

--- a/app/routes/api/spot/controller.js
+++ b/app/routes/api/spot/controller.js
@@ -4,9 +4,7 @@ const { errorMessages } = require("../errors");
 module.exports = {
   async getSpots(req, res, next) {
     try {
-      const active =
-        typeof req.query.active === "boolean" ? req.query.active : true;
-      const spots = await SpotService.listSpots(active);
+      const spots = await SpotService.listSpots();     
       res.json(spots);
     } catch (error) {
       next(error);

--- a/app/routes/api/spot/router.js
+++ b/app/routes/api/spot/router.js
@@ -4,9 +4,7 @@ const { authorizeTrafficLogAdmins, validateId } = require("../validators");
 const { checkErrors } = require("../errors");
 const controller = require("./controller");
 
-const validateActive = query("active").optional().toBoolean();
-
-router.get("/", validateActive, checkErrors, controller.getSpots);
+router.get("/", checkErrors, controller.getSpots);
 
 router.post("/", authorizeTrafficLogAdmins, checkErrors, controller.addSpot);
 

--- a/app/services/spot.service.js
+++ b/app/services/spot.service.js
@@ -9,14 +9,10 @@ async function getConstraintsForSpot(key) {
   return result.entities;
 }
 
-async function getAllCopyForSpot(key, includeExpired = false) {
+async function getAllCopyForSpot(key) {
   const options = {
-    filters: [["spot", key]],
+    filters: [["spot", key], ["deleted", false]],
   };
-  if (includeExpired === false) {
-    options.filters.push(["expire_on", null]);
-  }
-
   const { entities: copy } = await SpotCopy.list(options);
   return copy;
 }
@@ -33,18 +29,16 @@ async function getSpot(id) {
   return plain;
 }
 
-async function listSpots(active = true, includeCopy = true) {
+async function listSpots() {
   const options = {
     format: "ENTITY",
-    filters: ["active", active],
+    filters: ["active", true],
   };
   const { entities: spots } = await Spot.list(options);
   const response = await Promise.all(
     spots.map(async function (spot) {
       const plain = spot.plain({ showKey: true });
-      if (includeCopy) {
-        plain.copy = await getAllCopyForSpot(plain.__key);
-      }
+      plain.copy = await getAllCopyForSpot(plain.__key);
       return plain;
     })
   );

--- a/client/src/scss/styles.scss
+++ b/client/src/scss/styles.scss
@@ -43,7 +43,7 @@ $primary: #822036;
 // @import "~bootstrap/scss/offcanvas"; // Requires transitions
 // @import "~bootstrap/scss/placeholders";
 
-@import "~bootstrap/scss/helpers/ratio";
+@import "~bootstrap/scss/helpers";
 
 // Utilities
 @import "~bootstrap/scss/utilities/api";

--- a/client/src/traffic-log/components/SpotCopyItem.vue
+++ b/client/src/traffic-log/components/SpotCopyItem.vue
@@ -12,9 +12,9 @@
       class="flex-grow-1 h-100 overflow-hidden fw-normal font-serif me-2"
       :for="id"
     >
-      <span>{{ title }}</span>
-      <span v-if="!started"> (not started)</span>
+      <span>{{ title }}</span>     
     </label>
+    <span class="badge me-2 fw-normal" :class="badgeClasses" >{{badgeLabel}}</span>
     <router-link
       :to="{
         name: 'editSpotCopy',
@@ -37,7 +37,7 @@
 </style>
 
 <script>
-import { copyStarted } from "../functions";
+import { copyStarted, copyExpired } from "../functions";
 
 export default {
   name: "SpotCopyItem",
@@ -63,6 +63,24 @@ export default {
     },
     started() {
       return copyStarted(this.copy.start_on);
+    },
+    expired() {
+      return copyExpired(this.copy.expire_on);
+    },
+    badgeLabel() {      
+      if (this.expired) {
+        return "expired";
+      } else if (this.started) {
+        return "started";
+      }
+
+      return "not started";
+    },
+    badgeClasses() {
+      return {
+        "text-bg-secondary": this.expired || !this.started,
+        "text-bg-warning": this.started && !this.expired,
+      };
     },
     classes() {
       return {

--- a/client/src/traffic-log/components/SpotCopyItem.vue
+++ b/client/src/traffic-log/components/SpotCopyItem.vue
@@ -12,9 +12,11 @@
       class="flex-grow-1 h-100 overflow-hidden fw-normal font-serif me-2"
       :for="id"
     >
-      <span>{{ title }}</span>     
+      <span>{{ title }}</span>
     </label>
-    <span class="badge me-2 fw-normal" :class="badgeClasses" >{{badgeLabel}}</span>
+    <span class="badge me-2 fw-normal" :class="badgeClasses">{{
+      badgeLabel
+    }}</span>
     <router-link
       :to="{
         name: 'editSpotCopy',
@@ -67,7 +69,7 @@ export default {
     expired() {
       return copyExpired(this.copy.expire_on);
     },
-    badgeLabel() {      
+    badgeLabel() {
       if (this.expired) {
         return "expired";
       } else if (this.started) {
@@ -84,8 +86,8 @@ export default {
     },
     classes() {
       return {
-        "bg-warning-subtle": this.started,
-        "bg-light": !this.started,
+        "bg-light": this.expired || !this.started,
+        "bg-warning-subtle": this.started && !this.expired,
       };
     },
   },

--- a/client/src/traffic-log/components/SpotCopyItem.vue
+++ b/client/src/traffic-log/components/SpotCopyItem.vue
@@ -66,8 +66,8 @@ export default {
     },
     classes() {
       return {
-        "bg-warning-subtle": !this.started,
-        "bg-light": this.started,
+        "bg-warning-subtle": this.started,
+        "bg-light": !this.started,
       };
     },
   },

--- a/client/src/traffic-log/components/SpotCopyList.vue
+++ b/client/src/traffic-log/components/SpotCopyList.vue
@@ -47,7 +47,7 @@ export default {
       type: Object,
       required: true,
     },
-    future: Boolean,
+    notStarted: Boolean,
   },
   watch: {
     spot: {
@@ -77,7 +77,7 @@ export default {
   },
   computed: {
     filteredCopy() {
-      if (this.future) {
+      if (this.notStarted) {
         return this.spot.copy.filter(
           (copy) => copy.start_on && !copyStarted(copy.start_on)
         );

--- a/client/src/traffic-log/components/SpotCopyList.vue
+++ b/client/src/traffic-log/components/SpotCopyList.vue
@@ -29,7 +29,7 @@
 
 <script>
 import SpotCopyItem from "./SpotCopyItem.vue";
-import { copyStarted } from "../functions";
+import { copyStarted, copyExpired } from "../functions";
 
 const SELECT = "select";
 
@@ -47,7 +47,7 @@ export default {
       type: Object,
       required: true,
     },
-    notStarted: Boolean,
+    filter: String,
   },
   watch: {
     spot: {
@@ -77,13 +77,22 @@ export default {
   },
   computed: {
     filteredCopy() {
-      if (this.notStarted) {
-        return this.spot.copy.filter(
-          (copy) => copy.start_on && !copyStarted(copy.start_on)
-        );
+      switch (this.filter) {
+        case "expired":
+          return this.spot.copy.filter((copy) => copyExpired(copy.expire_on));
+        case "started":
+          return this.spot.copy.filter(
+            (copy) => copyStarted(copy.start_on) && !copyExpired(copy.expire_on)
+          );
+        case "notStarted":
+          return this.spot.copy.filter(
+            (copy) =>
+              !copyStarted(copy.start_on) && !copyExpired(copy.expire_on)
+          );
+        case "all":
+        default:
+          return this.spot.copy || [];
       }
-
-      return this.spot.copy || [];
     },
     showCheckAll() {
       return this.filteredCopy.length > 1;

--- a/client/src/traffic-log/functions.js
+++ b/client/src/traffic-log/functions.js
@@ -15,3 +15,10 @@ export const copyStarted = function (start_on) {
 
   return false;
 };
+
+export const copyExpired = function (expire_on) {
+  if (expire_on) {
+    const expire = new Date(expire_on.slice(0, 19));
+    return expire < Date.now();
+  }
+};

--- a/client/src/traffic-log/store.js
+++ b/client/src/traffic-log/store.js
@@ -35,8 +35,8 @@ export const useSpotsStore = defineStore("spots", {
   actions: {
     async getSpots() {
       this.loadingSpots = true;
-      const { data } = await api.get("/spot");
-      this.spots = data.sort(sortSpotsByTitle);
+      const { data: spots } = await api.get("/spot");
+      this.spots = spots.sort(sortSpotsByTitle);
       this.spots.forEach((spot) => spot.copy.sort(sortCopyByLastUpdated));
       this.loadingSpots = false;
       this.loadedSpots = true;

--- a/client/src/traffic-log/views/SpotsView.vue
+++ b/client/src/traffic-log/views/SpotsView.vue
@@ -21,16 +21,58 @@
                 </option>
               </select>
             </div>
-            <div class="col-2 ps-0">
+            <div class="col-2 ps-0 d-inline-flex">
+              <div class="form-check me-4">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="copyFilter"
+                  id="allCopyRadio"
+                  v-model="copyFilter"
+                  value="all"
+                />
+                <label class="form-check-label" for="allCopyRadio"> All </label>
+              </div>
+              <div class="form-check me-4">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="copyFilter"
+                  id="startedCopyRadio"
+                  v-model="copyFilter"
+                  value="started"
+                />
+                <label class="form-check-label" for="startedCopyRadio">
+                  Started
+                </label>
+              </div>
+              <div class="form-check me-4">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="copyFilter"
+                  id="notStartedCopyRadio"
+                  v-model="copyFilter"
+                  value="notStarted"
+                />
+                <label
+                  class="form-check-label text-nowrap"
+                  for="notStartedCopyRadio"
+                >
+                  Not Started
+                </label>
+              </div>
               <div class="form-check">
                 <input
                   class="form-check-input"
-                  type="checkbox"
-                  id="notStartedCopy"
-                  v-model="notStarted"
+                  type="radio"
+                  name="copyFilter"
+                  id="expiredCopyRadio"
+                  v-model="copyFilter"
+                  value="expired"
                 />
-                <label class="form-check-label" for="notStarted">
-                  Not Started
+                <label class="form-check-label" for="expiredCopyRadio">
+                  Expired
                 </label>
               </div>
             </div>
@@ -53,7 +95,7 @@
                 :spot="spot"
                 ref="lists"
                 @select="onSelect"
-                :not-started="notStarted"
+                :filter="copyFilter"
               />
             </div>
           </div>
@@ -94,7 +136,7 @@ export default {
       typeFilter: "",
       updatingCopy: false,
       types,
-      notStarted: false,
+      copyFilter: "all",
     };
   },
   computed: {

--- a/client/src/traffic-log/views/SpotsView.vue
+++ b/client/src/traffic-log/views/SpotsView.vue
@@ -26,11 +26,11 @@
                 <input
                   class="form-check-input"
                   type="checkbox"
-                  id="futureCopy"
-                  v-model="futureCopy"
+                  id="notStartedCopy"
+                  v-model="notStarted"
                 />
-                <label class="form-check-label" for="futureCopy">
-                  Future
+                <label class="form-check-label" for="notStarted">
+                  Not Started
                 </label>
               </div>
             </div>
@@ -53,7 +53,7 @@
                 :spot="spot"
                 ref="lists"
                 @select="onSelect"
-                :future="futureCopy"
+                :not-started="notStarted"
               />
             </div>
           </div>
@@ -94,7 +94,7 @@ export default {
       typeFilter: "",
       updatingCopy: false,
       types,
-      futureCopy: false,
+      notStarted: false,
     };
   },
   computed: {


### PR DESCRIPTION
Trello: https://trello.com/c/xxl63h1o

- Add `deleted` property to all spots and copy and set values that match their current state in the DJDB
  - Introduces a couple more "migrations", which are more like utility scripts than proper up/down migrations
- Update the /spots endpoint to return any copy that isn’t deleted
- Add badge and filter for copy based on status
  - This deviates from the interactive wireframes, but in a way I think will help minimize the potential for mode confusion by switching between tabs just to see expired copy

<img width="1037" alt="Screenshot 2024-03-09 at 2 46 05 PM" src="https://github.com/chirpradio/nextup/assets/772939/13387cba-6e6e-47d1-acae-f69620f1500d">
