### PR TITLE
Add matched album categories to freeform rotation track

### DIFF
--- a/app/routes/tasks/tasks.controller.js
+++ b/app/routes/tasks/tasks.controller.js
@@ -7,6 +7,12 @@ const {
   SearchService,
 } = require("../../services");
 const levenshtein = require("js-levenshtein");
+const validTags = [
+  "local_current",
+  "local_classic",
+  "heavy_rotation",
+  "light_rotation",
+];
 
 async function updateIndexWithAlbumArtist(artist) {
   await SearchService.update(
@@ -190,6 +196,9 @@ async function updateFreeformRotationPlays(req, res) {
             playlistTrack.album = track.album;
             playlistTrack.artist = album.album_artist.__key;
             playlistTrack.track = track.__key;
+            playlistTrack.categories = album.current_tags.filter((tag) =>
+              validTags.includes(tag)
+            );
             const { error } = playlistTrack.validate();
             if (!error) {
               await playlistTrack.save();


### PR DESCRIPTION
DJs can play rotation tracks even when they enter them freeform, which makes it harder to report on them later. This code has been running as a cron job every few hours for the last few years to match those freeform tracks to their Album, Track, and Artist items in the Datastore to help improve the accuracy of the rotation reports.

This cron job has started causing errors in the DJDB when a DJ enters a track from an album in rotation freeform but doesn't select the rotation category for it. This fix handles that by adding the categories/tags from the matched Album, but only those that are valid for a freeform playlist track.