### PR TITLE
Fix issues when using multiple tabs

### DIFF
--- a/client/src/components/AddToCrate.vue
+++ b/client/src/components/AddToCrate.vue
@@ -63,14 +63,6 @@ export default {
       };
     },
   },
-  async created() {
-    if (
-      this.cratesStore.crates.length === 0 &&
-      !this.cratesStore.loadingCrates
-    ) {
-      await this.cratesStore.getCrates();
-    }
-  },
   methods: {
     async addTo(crate) {
       this.added = false;

--- a/client/src/playlist/components/PlaylistTrack.vue
+++ b/client/src/playlist/components/PlaylistTrack.vue
@@ -57,15 +57,15 @@
       confirmLabel="delete from playlist"
     >
       <p>
-        Deleting the track will not update chirpradio.org or the mobile apps, but it will be removed from Music Department reporting.
+        Deleting the track will not update chirpradio.org or the mobile apps,
+        but it will be removed from Music Department reporting.
       </p>
       <p class="text-danger">
-        <span class="fw-bold">{{ artist }}</span> 
+        <span class="fw-bold">{{ artist }}</span>
         <span> “{{ title }}” from</span>
         <span class="fst-italic">&nbsp;{{ album }}</span>
         <span> ({{ label }})</span>
       </p>
-      
     </Modal>
   </div>
 </template>

--- a/client/src/playlist/store.js
+++ b/client/src/playlist/store.js
@@ -71,7 +71,14 @@ export const usePlaylistStore = defineStore("playlist", {
       }
 
       const { data: events } = await api.get("/playlist", options);
-      this.events = [...this.events, ...events];
+      for (const event of events) {
+        const index = this.events.findIndex((item) => item.id === event.id);
+        if (index > -1) {
+          this.events.splice(index, 1, event);
+        } else {
+          this.events.push(event);
+        }
+      }
       this.lastUpdated = Date.now();
     },
     async getRecentRotationPlays() {

--- a/client/src/playlist/views/PlaylistView.vue
+++ b/client/src/playlist/views/PlaylistView.vue
@@ -162,9 +162,7 @@ export default {
     },
   },
   created: async function () {
-    if (this.events.length === 0) {
-      this.update();
-    }
+    this.update();
     this.playlistStore.pollRotationPlays();
   },
   mounted() {

--- a/client/src/services/api.service.js
+++ b/client/src/services/api.service.js
@@ -90,50 +90,6 @@ export default {
     return await getAndHandleError(getter);
   },
 
-  async getCrates() {
-    const getter = instance.get("/crate");
-    return await getAndHandleError(getter);
-  },
-
-  async getCrate(crateId) {
-    const getter = instance.get(`/crate/${crateId}`);
-    return await getAndHandleError(getter);
-  },
-
-  async getCrateItems(crateId) {
-    const getter = instance.get(`/crate/${crateId}/items`);
-    return await getAndHandleError(getter);
-  },
-
-  async addToCrate(crateId, params) {
-    const response = await instance.post(`/crate/${crateId}/item`, params);
-    return response.data;
-  },
-
-  async removeFromCrate(crateId, index) {
-    await instance.delete(`crate/${crateId}/item/${index}`);
-  },
-
-  async reorderItemInCrate(crateId, index, newIndex) {
-    await instance.patch(`/crate/${crateId}/item/${index}/reorder/${newIndex}`);
-  },
-
-  async addCrate(name) {
-    return await instance.post(`/crate/`, {
-      name,
-    });
-  },
-
-  async renameCrate(crateId, name) {
-    await instance.patch(`/crate/${crateId}`, {
-      name,
-    });
-  },
-
-  async deleteCrate(crateId) {
-    await instance.delete(`/crate/${crateId}`);
-  },
-
   async search(params) {
     const getter = instance.get("/search", {
       params,

--- a/client/src/stores/crates.js
+++ b/client/src/stores/crates.js
@@ -110,6 +110,7 @@ export const useCratesStore = defineStore("crates", () => {
     }
   });
 
+
   return { 
     // state
     crates, 
@@ -130,7 +131,8 @@ export const useCratesStore = defineStore("crates", () => {
     removeItem, 
     reorderItem 
   }; 
-  // persist: {
-  //   paths: ["lastAddedTo"],
-  // },
-});
+}, {
+  persist: {
+    paths: ["lastAddedTo"],
+  },
+} );

--- a/client/src/stores/crates.js
+++ b/client/src/stores/crates.js
@@ -98,6 +98,15 @@ export const useCratesStore = defineStore("crates", () => {
     await api.patch(`/crate/${crateId}/item/${index}/reorder/${newIndex}`);
   }
 
+  // load crates for user
+  const auth = useAuthStore();
+  const { isAuthenticated } = storeToRefs(auth);
+  if(isAuthenticated.value === true) {
+    getCrates();
+  };
+  watch(isAuthenticated, (value) => {
+    if(value === true) {
+      getCrates();
     }
   });
 

--- a/client/src/stores/crates.js
+++ b/client/src/stores/crates.js
@@ -1,138 +1,143 @@
 import { defineStore } from "pinia";
 import { api } from "../services/api.service";
 import { useAuthStore } from "./auth";
-import { watch, ref, computed } from 'vue'
-import { storeToRefs } from 'pinia'
+import { watch, ref, computed } from "vue";
+import { storeToRefs } from "pinia";
 
+export const useCratesStore = defineStore(
+  "crates",
+  () => {
+    // state
+    const crates = ref([]);
+    const items = ref({});
+    const loadingCrates = ref(false);
+    const lastAddedTo = ref();
 
-export const useCratesStore = defineStore("crates", () => {
-  // state
-  const crates = ref([]);
-  const items = ref({});
-  const loadingCrates = ref(false);
-  const lastAddedTo = ref();
-  
-  function findCrate(crateId) {    
-    return crates.value.find((crate) => crate.id === crateId);
-  }
-  
-  function sortCrates(crates) {
-    crates.value.sort((a, b) => {
-      if (a.name === b.name || !a.name || !b.name) {
-        return 0;
-      }
-      return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
+    function findCrate(crateId) {
+      return crates.value.find((crate) => crate.id === crateId);
+    }
+
+    function sortCrates(crates) {
+      crates.value.sort((a, b) => {
+        if (a.name === b.name || !a.name || !b.name) {
+          return 0;
+        }
+        return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
+      });
+    }
+
+    // getters
+    const crate = computed(() => (id) => {
+      return findCrate(id);
     });
-  }
 
-  // getters
-  const crate = computed(() => (id) => {
-    return findCrate(id);
-  });
-
-  const crateItems = computed(() => (id) => {
-    return items.value[id];
-  });
-
-  // actions
-  async function getCrates() {
-    loadingCrates.value = true;
-    const response = await api.get("/crate");
-    crates.value = response.data;
-    sortCrates(crates);
-    loadingCrates.value = false;
-  }
-
-  async function getCrate({ crateId }) {
-    loadingCrates.value = true;
-    const { data: crate } = await api.get(`/crate/${crateId}`);
-    items.value[crateId] = [];
-    crate.order = crate.order || [];
-    crates.value.push(crate);
-    loadingCrates.value = false;
-  }
-
-  async function addCrate({ name }) {
-    const { data: crate } = await api.post(`/crate/`, { name });
-    crates.value.push(crate);
-    sortCrates(crates);
-    return crate;
-  }
-
-  async function renameCrate({ crateId, name }) {
-    await api.patch(`/crate/${crateId}`, {
-      name,
+    const crateItems = computed(() => (id) => {
+      return items.value[id];
     });
-    const crate = findCrate(crateId);
-    crate.name = name;
-  }
 
-  async function deleteCrate({ crateId }) {
-    const index = crates.value.findIndex((element) => element.id === crateId);
-    crates.value.splice(index, 1);
-    await api.delete(`/crate/${crateId}`);
-  }
+    // actions
+    async function getCrates() {
+      loadingCrates.value = true;
+      const response = await api.get("/crate");
+      crates.value = response.data;
+      sortCrates(crates);
+      loadingCrates.value = false;
+    }
 
-  async function getCrateItems({ crateId }) {
-    const { data: loadedItems } = await api.get(`/crate/${crateId}/items`);
-    items.value[crateId] = loadedItems;
-  }
+    async function getCrate({ crateId }) {
+      loadingCrates.value = true;
+      const { data: crate } = await api.get(`/crate/${crateId}`);
+      items.value[crateId] = [];
+      crate.order = crate.order || [];
+      crates.value.push(crate);
+      loadingCrates.value = false;
+    }
 
-  async function addToCrate({ crateId, params }) {
-    const { data: loadedItems } = await api.post(`/crate/${crateId}/item`, params);
-    items.value[crateId] = loadedItems;
+    async function addCrate({ name }) {
+      const { data: crate } = await api.post(`/crate/`, { name });
+      crates.value.push(crate);
+      sortCrates(crates);
+      return crate;
+    }
 
-    const crate = findCrate(crateId);
-    crate.totalItems++;
-    lastAddedTo.value = crate;
-  }
+    async function renameCrate({ crateId, name }) {
+      await api.patch(`/crate/${crateId}`, {
+        name,
+      });
+      const crate = findCrate(crateId);
+      crate.name = name;
+    }
 
-  async function removeItem({ crateId, index }) {
-    const crate = findCrate(crateId);
-    items.value[crateId].splice(index, 1);
-    crate.totalItems--;
-    await api.delete(`crate/${crateId}/item/${index}`);
-  }
+    async function deleteCrate({ crateId }) {
+      const index = crates.value.findIndex((element) => element.id === crateId);
+      crates.value.splice(index, 1);
+      await api.delete(`/crate/${crateId}`);
+    }
 
-  async function reorderItem({ crateId, index, newIndex }) {
-    await api.patch(`/crate/${crateId}/item/${index}/reorder/${newIndex}`);
-  }
+    async function getCrateItems({ crateId }) {
+      const { data: loadedItems } = await api.get(`/crate/${crateId}/items`);
+      items.value[crateId] = loadedItems;
+    }
 
-  // load crates for user
-  const auth = useAuthStore();
-  const { isAuthenticated } = storeToRefs(auth);
-  if(isAuthenticated.value === true) {
-    getCrates();
-  };
-  watch(isAuthenticated, (value) => {
-    if(value === true) {
+    async function addToCrate({ crateId, params }) {
+      const { data: loadedItems } = await api.post(
+        `/crate/${crateId}/item`,
+        params
+      );
+      items.value[crateId] = loadedItems;
+
+      const crate = findCrate(crateId);
+      crate.totalItems++;
+      lastAddedTo.value = crate;
+    }
+
+    async function removeItem({ crateId, index }) {
+      const crate = findCrate(crateId);
+      items.value[crateId].splice(index, 1);
+      crate.totalItems--;
+      await api.delete(`crate/${crateId}/item/${index}`);
+    }
+
+    async function reorderItem({ crateId, index, newIndex }) {
+      await api.patch(`/crate/${crateId}/item/${index}/reorder/${newIndex}`);
+    }
+
+    // load crates for user
+    const auth = useAuthStore();
+    const { isAuthenticated } = storeToRefs(auth);
+    if (isAuthenticated.value === true) {
       getCrates();
     }
-  });
+    watch(isAuthenticated, (value) => {
+      if (value === true) {
+        getCrates();
+      }
+    });
 
-
-  return { 
-    // state
-    crates, 
-    items, 
-    loadingCrates, 
-    lastAddedTo, 
-    // getters
-    crate, 
-    crateItems, 
-    // actions
-    getCrates, 
-    getCrate, 
-    addCrate, 
-    renameCrate, 
-    deleteCrate, 
-    getCrateItems, 
-    addToCrate, 
-    removeItem, 
-    reorderItem 
-  }; 
-}, {
-  persist: {
-    paths: ["lastAddedTo"],
+    return {
+      // state
+      crates,
+      items,
+      loadingCrates,
+      lastAddedTo,
+      // getters
+      crate,
+      crateItems,
+      // actions
+      getCrates,
+      getCrate,
+      addCrate,
+      renameCrate,
+      deleteCrate,
+      getCrateItems,
+      addToCrate,
+      removeItem,
+      reorderItem,
+    };
   },
-} );
+  {
+    persist: {
+      paths: ["lastAddedTo"],
+    },
+  }
+);

--- a/client/src/views/crates/CrateView.vue
+++ b/client/src/views/crates/CrateView.vue
@@ -250,7 +250,7 @@ export default {
     async deleteCrate() {
       this.hideDeleteModal();
       this.loading = true;
-      await this.cratesStore.deleteCrate({ crateId: this.id });      
+      await this.cratesStore.deleteCrate({ crateId: this.id });
       this.$router.push({ path: "/crates" });
     },
     scrollToBottom() {

--- a/client/src/views/crates/CrateView.vue
+++ b/client/src/views/crates/CrateView.vue
@@ -197,7 +197,7 @@ export default {
       return name;
     },
     showList() {
-      return this.crate && this.items && this.items.length;
+      return this.crate && this.items && this.items.length && !this.loading;
     },
   },
   created: async function () {
@@ -247,9 +247,10 @@ export default {
     showAddModal() {
       this.$refs.addModal.show();
     },
-    deleteCrate() {
+    async deleteCrate() {
       this.hideDeleteModal();
-      this.cratesStore.deleteCrate({ crateId: this.id });
+      this.loading = true;
+      await this.cratesStore.deleteCrate({ crateId: this.id });      
       this.$router.push({ path: "/crates" });
     },
     scrollToBottom() {


### PR DESCRIPTION
# Playlist events doubling
When a user had the playlist open in one tab and another NextUp tab open to any other page, tracks and breaks in the playlist were showing up doubled (and kept tripling, quadrupling, etc., as a user would refresh). The change in the second commit, 22954f5, handles that: checking if the PlaylistEvent id is already in the array before adding what was just retrieved. The order doesn't matter in the store, that sorting is handled in the PlaylistView.

# Crates emptying
> Normally when I start my show, I open my crate, and then from there I open (in separate tabs) all the albums from rotation that I want to play from my crate. (Most people can’t plan ahead with rotation so this isn’t going to be a widespread issue.) What I found is that when I open the new tab, the contents of the crate disappear. (I get a “the crate is empty” message.) If I reload the page, it all reappears, but it did scare me, thinking I’d accidentally cleared out my crate.

This one required a more involved change. The root of the issue is that we're currently using a plugin to share state between tabs. The AddToCrate button that's all over any album page had a check in it to see if crates had already been retrieved before getting them again, but that check was running before the plugin got the state (and the user's crates) from the other tab. 

The plugin doesn't have a hook that would allow us to easily wait for and react to that sharing, so I set up a watcher inside the crates store to check whether a user is authenticated when it's installed and watch for a new user after that (8124b8d). Handling that inside the crates store required a change from the options API, where everything's defined by a structured object, to a [setup store](https://pinia.vuejs.org/core-concepts/#Setup-Stores), where the same store is defined in a setup function. 

While I was making a big ol' change to the crates store and retesting all its functionality anyway, I also:
* shifted the API calls from functions in api.service.js to more direct calls in the store. This matches a change I've been pursuing in other stores to remove an unnecessary level of obfuscation about what each store action is _actually_ doing.
* fixed a small bug where a deleted crate name was still showing up in the crates list (328b68c).