### PR TITLE
Bugfix/albums sort by year

### DIFF
--- a/client/src/components/music/AlbumCollection.vue
+++ b/client/src/components/music/AlbumCollection.vue
@@ -30,13 +30,18 @@
 <script>
 import AlbumCard from "./AlbumCard.vue";
 import RecordSpinner from "../RecordSpinner.vue";
-import { shuffle, orderBy } from "lodash";
+import { shuffle, orderBy, get, sortBy } from "lodash";
 
 function compareByProperty(array, prop) {
-  if ( prop === "year") {
+  if (prop === "year") {
     return orderBy(array, [prop], ["desc"]);
   } else {
-    return orderBy(array, [prop], ["asc"]);
+    return sortBy(array, [
+      function (album) {
+        const value = get(album, prop);
+        return typeof value === "string" ? value.toLowerCase() : null;
+      },
+    ]);
   }
 }
 

--- a/client/src/components/music/AlbumCollection.vue
+++ b/client/src/components/music/AlbumCollection.vue
@@ -30,15 +30,14 @@
 <script>
 import AlbumCard from "./AlbumCard.vue";
 import RecordSpinner from "../RecordSpinner.vue";
-import { get, shuffle, sortBy } from "lodash";
+import { shuffle, orderBy } from "lodash";
 
 function compareByProperty(array, prop) {
-  return sortBy(array, [
-    function (album) {
-      const value = get(album, prop);
-      return typeof value === "string" ? value.toLowerCase() : null;
-    },
-  ]);
+  if ( prop === "year") {
+    return orderBy(array, [prop], ["desc"]);
+  } else {
+    return orderBy(array, [prop], ["asc"]);
+  }
 }
 
 export default {


### PR DESCRIPTION
Added special handling for years to use lodash's [`orderBy`](https://lodash.com/docs/4.17.15#orderBy) which allows for specifying sort direction. 