### PR TITLE
Consistent traffic log spots

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -14,7 +14,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "parserOptions": {
-        "ecmaVersion": 2018
+        "ecmaVersion": 2020
     },
     "plugins": ["prettier"],
     "rules": {

--- a/app/routes/api/specification.yaml
+++ b/app/routes/api/specification.yaml
@@ -1049,9 +1049,27 @@ paths:
       tags:
         - Traffic Log
       description: 
-        Returns a list of traffic log entries for the next three hours, starting at the top of the current hour.
+        Returns a list of traffic log entries for the given weekday and hour.
         Entries that have already been read have values for "logtime", "readtime", "reader", or "__key".
         Entries still to be read have a random copy but no values for those properties. They can be posted to the API to be saved to the database.       
+      parameters:
+        - name: dow          
+          in: query
+          required: false          
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 7
+            default: current weekday in Chicago
+          description: Weekday (1 = Monday, 7 = Sunday)
+        - name: hour          
+          in: query
+          required: false          
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 23
+            default: current hour in Chicago
       responses:
         '200':
           description: Success

--- a/app/routes/api/traffic-log/controller.js
+++ b/app/routes/api/traffic-log/controller.js
@@ -4,7 +4,7 @@ module.exports = {
   async getLog(req, res, next) {
     try {
       const dow = req.query.dow || DateService.currentChicagoWeekday();
-      const hour = req.query.hour || DateService.currentChicagoHour();
+      const hour = Number.isInteger(req.query.hour) ? req.query.hour : DateService.currentChicagoHour();
       const length = req.query.length || 1;
       const log = await TrafficLogService.getLog(dow, hour, length);
       res.json(log);

--- a/app/routes/api/traffic-log/controller.js
+++ b/app/routes/api/traffic-log/controller.js
@@ -3,11 +3,11 @@ const { DateService, TrafficLogService } = require("../../../services");
 module.exports = {
   async getLog(req, res, next) {
     try {
-      const entries = await TrafficLogService.getLog(
-        DateService.currentChicagoWeekday(),
-        DateService.currentChicagoHour()
-      );
-      res.json(entries);
+      const dow = req.query.dow || DateService.currentChicagoWeekday();
+      const hour = req.query.hour || DateService.currentChicagoHour();
+      const length = req.query.length || 1;
+      const log = await TrafficLogService.getLog(dow, hour, length);
+      res.json(log);
     } catch (error) {
       next(error);
     }

--- a/app/routes/api/traffic-log/controller.js
+++ b/app/routes/api/traffic-log/controller.js
@@ -4,9 +4,10 @@ module.exports = {
   async getLog(req, res, next) {
     try {
       const dow = req.query.dow || DateService.currentChicagoWeekday();
-      const hour = Number.isInteger(req.query.hour) ? req.query.hour : DateService.currentChicagoHour();
-      const length = req.query.length || 1;
-      const log = await TrafficLogService.getLog(dow, hour, length);
+      const hour = Number.isInteger(req.query.hour)
+        ? req.query.hour
+        : DateService.currentChicagoHour();
+      const log = await TrafficLogService.getLog(dow, hour);
       res.json(log);
     } catch (error) {
       next(error);

--- a/app/routes/api/traffic-log/router.js
+++ b/app/routes/api/traffic-log/router.js
@@ -4,19 +4,11 @@ const {
   validateStart,
   validateDow,
   validateHour,
-  validateLength,
 } = require("./validators");
 const { checkErrors } = require("../errors");
 const controller = require("./controller");
 
-router.get(
-  "/",
-  validateDow,
-  validateHour,
-  validateLength,
-  checkErrors,
-  controller.getLog
-);
+router.get("/", validateDow, validateHour, checkErrors, controller.getLog);
 
 router.post("/", controller.addEntry);
 

--- a/app/routes/api/traffic-log/router.js
+++ b/app/routes/api/traffic-log/router.js
@@ -1,10 +1,7 @@
 const router = require("express").Router();
-const { query } = require("express-validator");
+const { validateEnd, validateStart } = require("./validators");
 const { checkErrors } = require("../errors");
 const controller = require("./controller");
-
-const validateStart = query("start").isISO8601();
-const validateEnd = query("end").isISO8601();
 
 router.get("/", controller.getLog);
 

--- a/app/routes/api/traffic-log/router.js
+++ b/app/routes/api/traffic-log/router.js
@@ -1,9 +1,22 @@
 const router = require("express").Router();
-const { validateEnd, validateStart } = require("./validators");
+const {
+  validateEnd,
+  validateStart,
+  validateDow,
+  validateHour,
+  validateLength,
+} = require("./validators");
 const { checkErrors } = require("../errors");
 const controller = require("./controller");
 
-router.get("/", controller.getLog);
+router.get(
+  "/",
+  validateDow,
+  validateHour,
+  validateLength,
+  checkErrors,
+  controller.getLog
+);
 
 router.post("/", controller.addEntry);
 

--- a/app/routes/api/traffic-log/validators.js
+++ b/app/routes/api/traffic-log/validators.js
@@ -3,7 +3,6 @@ const { query } = require("express-validator");
 module.exports = {
   validateDow: query("dow").optional().isInt({ min: 1, max: 7 }).toInt(),
   validateHour: query("hour").optional().isInt({ min: 0, max: 23 }).toInt(),
-  validateLength: query("length").optional().isInt({ min: 1, max: 3 }).toInt(),
   validateStart: query("start").isISO8601(),
   validateEnd: query("end").isISO8601(),
 };

--- a/app/routes/api/traffic-log/validators.js
+++ b/app/routes/api/traffic-log/validators.js
@@ -1,0 +1,9 @@
+const { query } = require("express-validator");
+
+module.exports = {
+  validateDow: query("dow").optional().isInt({ min: 1, max: 7 }).toInt(),
+  validateHour: query("hour").optional().isInt({ min: 0, max: 23 }).toInt(),
+  validateLength: query("length").optional().isInt({ min: 1, max: 3 }).toInt(),
+  validateStart: query("start").isISO8601(),
+  validateEnd: query("end").isISO8601(),
+};

--- a/app/services/spot.service.js
+++ b/app/services/spot.service.js
@@ -73,7 +73,7 @@ async function updateSpot(id, data) {
     const current = await getConstraintsForSpot(spotKey);
     const currentIds = current.map((constraint) => constraint.id);
     const removed = currentIds.filter((id) => !data.constraints.includes(id));
-    const added = data.constraints.filter((id) => !currentIds.includes(id));    
+    const added = data.constraints.filter((id) => !currentIds.includes(id));
 
     const addPromises = added.map(async function (id) {
       return addSpotToConstraint(spotKey, id, transaction);

--- a/app/services/trafficLog.service.js
+++ b/app/services/trafficLog.service.js
@@ -163,12 +163,12 @@ function buildEntries(existingEntries, constraints, copy) {
     if (existingEntryForConstraint) {
       entry = existingEntryForConstraint;
     } else {
-      runningCopy = runningCopyForConstraint(copy, constraint);  
-      if(runningCopy.length === 0) {
+      runningCopy = runningCopyForConstraint(copy, constraint);
+      if (runningCopy.length === 0) {
         return result;
       }
 
-      entry = buildEntryStub(constraint);    
+      entry = buildEntryStub(constraint);
     }
 
     result.push({
@@ -224,7 +224,7 @@ async function addEntry(data, user) {
   data.reader = user;
   const now = new Date();
   data.readtime = now;
-  
+
   // matches DJDB
   data.log_date = DateTime.now()
     .minus({ days: 1 })

--- a/app/services/trafficLog.service.js
+++ b/app/services/trafficLog.service.js
@@ -152,7 +152,7 @@ function buildEntryStub(constraint) {
 }
 
 function buildEntries(existingEntries, constraints, copy) {
-  return constraints.map((constraint) => {
+  return constraints.reduce((result, constraint) => {
     let entry,
       runningCopy = [];
     const existingEntryForConstraint = findExistingEntryForConstraint(
@@ -163,19 +163,20 @@ function buildEntries(existingEntries, constraints, copy) {
     if (existingEntryForConstraint) {
       entry = existingEntryForConstraint;
     } else {
-      runningCopy = runningCopyForConstraint(copy, constraint);
-      if (runningCopy.length === 0) {
-        return;
+      runningCopy = runningCopyForConstraint(copy, constraint);  
+      if(runningCopy.length === 0) {
+        return result;
       }
 
-      entry = buildEntryStub(constraint);
+      entry = buildEntryStub(constraint);    
     }
 
-    return {
+    result.push({
       entry,
       copy: runningCopy,
-    };
-  });
+    });
+    return result;
+  }, []);
 }
 
 async function getLog(dow, hour, length = DEFAULT_LOG_LENGTH) {

--- a/app/services/trafficLog.service.js
+++ b/app/services/trafficLog.service.js
@@ -216,12 +216,15 @@ function checkForKey(prop, value) {
 }
 
 async function addEntry(data, user) {
-  data.spot = checkForKey("spot", data.spot);
+  // turn the populated spot back into its reference
+  data.spot = datastore.key(["Spot", parseInt(data.spot.id, 10)]);
+
   data.scheduled = checkForKey("scheduled", data.scheduled);
   data.spot_copy = checkForKey("spot_copy", data.spot_copy);
   data.reader = user;
   const now = new Date();
   data.readtime = now;
+  
   // matches DJDB
   data.log_date = DateTime.now()
     .minus({ days: 1 })

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
         "js-cookie": "^3.0.1",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
+        "luxon": "^3.5.0",
         "pinia": "^2.1.7",
         "pinia-plugin-persistedstate": "^3.2.1",
         "pinia-shared-state": "^0.5.1",
@@ -2949,6 +2950,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "js-cookie": "^3.0.1",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
+    "luxon": "^3.5.0",
     "pinia": "^2.1.7",
     "pinia-plugin-persistedstate": "^3.2.1",
     "pinia-shared-state": "^0.5.1",

--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -14,18 +14,18 @@
 
     <ul class="list-group">
       <button
-        v-for="entry in trafficLog"
-        :key="entry.scheduled.name"
+        v-for="slot in trafficLog"
+        :key="slot.entry.scheduled.name"
         class="list-group-item list-group-item-action list-group-item-light d-flex flex-row flex-md-column flex-lg-row"
         data-bs-toggle="offcanvas"
         data-bs-target="#spot"
         aria-controls="spot"
-        @click="select(entry)"
+        @click="select(slot.entry)"
       >
-        <span class="w-20">{{ time(entry) }}</span>
-        <div class="col" :class="titleClass(entry)">
+        <span class="w-20">{{ time(slot.entry) }}</span>
+        <div class="col" :class="titleClass(slot.entry)">
           <font-awesome-icon icon="square-caret-left" />
-          {{ entry.spot.title }}
+          {{ slot.entry.spot.title }}
         </div>
       </button>
     </ul>
@@ -79,7 +79,7 @@
 <script>
 import { Offcanvas } from "bootstrap"; // eslint-disable-line no-unused-vars
 import { mapStores } from "pinia";
-import { useSpotsStore } from "@/traffic-log/store";
+import { usePlaylistStore } from "../store";
 import LoadingButton from "@/components/LoadingButton.vue";
 import TrafficLogActions from "./TrafficLogActions.vue";
 
@@ -92,15 +92,15 @@ export default {
     };
   },
   computed: {
-    ...mapStores(useSpotsStore),
+    ...mapStores(usePlaylistStore),
     loading() {
-      return this.spotsStore.loadingTrafficLog;
+      return this.playlistStore.loadingTrafficLog;
     },
     trafficLog() {
-      return this.spotsStore.trafficLog;
+      return this.playlistStore.trafficLog;
     },
     selectedGroup() {
-      return this.spotsStore.group(this.selected);
+      return this.playlistStore.group(this.selected);
     },
     selectedIndexInGroup() {
       return this.selectedGroup?.indexOf(this.selected);
@@ -129,7 +129,7 @@ export default {
     },
   },
   mounted() {
-    this.spotsStore.getTrafficLog();
+    this.playlistStore.getTrafficLog();
     this.drawer = new Offcanvas(this.$refs.spot);
   },
   methods: {
@@ -146,7 +146,7 @@ export default {
       return `${this.time(entry)} ${entry.spot.title}`;
     },
     refresh() {
-      this.spotsStore.getTrafficLog();
+      this.playlistStore.getTrafficLog();
     },
     select(entry) {
       this.selected = entry;
@@ -161,7 +161,7 @@ export default {
       this.selected = this.nextInGroup;
     },
     async markAsRead() {
-      await this.spotsStore.addTrafficLogEntry(this.selected);
+      await this.playlistStore.addTrafficLogEntry(this.selected);
       if (this.nextInGroup) {
         this.next();
       } else {

--- a/client/src/playlist/store.js
+++ b/client/src/playlist/store.js
@@ -1,10 +1,106 @@
 import { defineStore } from "pinia";
 import { api } from "../services/api.service";
+import { DateTime } from "luxon";
+import { _ } from "lodash";
 
 let intervalID;
 const ROTATION_PLAY_WINDOW = 4; // hours
 const ROTATION_PLAY_POLLING_INTERVAL = 5 * 60 * 1000; // every five minutes
-const GROUP_SLOTS_WITHIN = 3; // minutes
+const GROUP_ENTRIES_WITHIN = 3; // minutes
+const TRAFFIC_LOG_POLLING_INTERVAL = 60 * 1000; // every minute
+
+function getChicagoWeekdayAndHour(hourOffset = 0) {
+  const dt = DateTime.now()
+    .setZone("America/Chicago")
+    .plus({ hours: hourOffset });
+  return { weekday: dt.weekday, hour: dt.hour };
+}
+
+function checkSlotsForUpdates(trafficLog) {
+  const needed = [getChicagoWeekdayAndHour(), getChicagoWeekdayAndHour(1)];
+
+  const current = _.chain(trafficLog)
+    .map((entry) => {
+      return {
+        weekday: entry.dow,
+        hour: entry.hour,
+      };
+    })
+    .uniqWith(_.isEqual)
+    .value();
+
+  const missing = needed.filter((pair) => {
+    return !trafficLog.some((entry) => {
+      return entry.dow === pair.weekday && entry.hour === pair.hour;
+    });
+  });
+
+  const outdated = current.filter((currentPair) => {
+    return !needed.some((neededPair) => {
+      return (
+        currentPair.weekday === neededPair.weekday &&
+        currentPair.hour === neededPair.hour
+      );
+    });
+  });
+
+  return {
+    missing,
+    outdated,
+  };
+}
+
+async function updateTrafficLog(store) {
+  const updates = checkSlotsForUpdates(store.trafficLog);
+
+  if (updates.outdated.length > 0) {
+    updates.outdated.forEach(({ weekday, hour }) => {
+      store.removeEntries(weekday, hour);
+    });
+  }
+  
+  if (updates.missing.length > 0) {
+    await Promise.all(updates.missing.map(store.getEntries));
+  }
+}
+
+function groupNearbyEntries(entries) {
+  let grouping = false;
+  let groups = [];
+
+  entries.forEach((entry, i) => {
+    if (grouping) {
+      groups.at(-1).push(entry);
+    }
+    if (i === entries.length - 1) {
+      return;
+    }
+
+    const nextEntry = entries[i + 1];
+    if (nextEntry.slot - entry.slot <= GROUP_ENTRIES_WITHIN) {
+      if (!grouping) {
+        groups.push([entry]);
+        grouping = true;
+      }
+    } else {
+      grouping = false;
+    }
+  });
+
+  return groups;
+}
+
+function sortEntries(a, b) {
+  if (a.hour === b.hour) {
+    return a.slot - b.slot;
+  } else if (a.hour === 0 && b.hour === 23) {
+    return 1;
+  } else if (a.hour === 23 && b.hour === 0) {
+    return -1;
+  } else {
+    return a.hour - b.hour;
+  }
+}
 
 export const usePlaylistStore = defineStore("playlist", {
   state: () => ({
@@ -31,7 +127,12 @@ export const usePlaylistStore = defineStore("playlist", {
       );
     },
     group: (state) => (entry) => {
-      return state.trafficLogGroups.find((group) => group.includes(entry));
+      if (!entry) return null;
+      return state.trafficLogGroups.find((group) =>
+        group.some(
+          (groupedEntry) => entry.scheduled.name === groupedEntry.scheduled.name
+        )
+      );
     },
   },
   actions: {
@@ -115,59 +216,46 @@ export const usePlaylistStore = defineStore("playlist", {
     selectAlbum(id) {
       this.selectedAlbumId = id;
     },
-    async getTrafficLog() {
+    async getEntries({ weekday, hour } = {}) {
       this.loadingTrafficLog = true;
-      const { data: slots } = await api.get("/traffic-log"); 
-      
-      slots.forEach((slot) => {
-        if(!slot.entry.spot_copy) {          
-          slot.entry.spot_copy = slot.copy[Math.floor(Math.random() * slot.copy.length)];
-          slot.entry.spot = slot.entry.spot_copy.spot;
-        }
+      const { data: entries } = await api.get("/traffic-log", {
+        params: {
+          dow: weekday,
+          hour,
+        },
       });
-
-      let grouping = false;
-      let groups = [];
-      slots.forEach((slot, i) => {
-        const entry = slot.entry;
-        
-        if (grouping) {
-          groups.at(-1).push(entry);
-        }
-        if (i === slots.length - 1) {
-          return;
-        }
-
-        const nextEntry = slots[i + 1].entry;
-        if (entry.spot && nextEntry?.spot) {
-          const slotTime = entry.hour * 60 + entry.slot;
-          const nextSlotTime = nextEntry.hour * 60 + nextEntry.slot;
-
-          if (nextSlotTime - slotTime <= GROUP_SLOTS_WITHIN) {
-            if (!grouping) {
-              groups.push([entry]);
-              grouping = true;
-            }
-          } else {
-            grouping = false;
-          }
-        }
-      });
-
-      this.trafficLog = slots;
-      this.trafficLogGroups = groups;
+      this.trafficLog = [...this.trafficLog, ...entries];
+      this.trafficLog.sort(sortEntries);
+      this.trafficLogGroups = [
+        ...this.trafficLogGroups,
+        ...groupNearbyEntries(entries),
+      ];
       this.loadingTrafficLog = false;
+    },
+    removeEntries(weekday, hour) {
+      this.trafficLog = this.trafficLog.filter((entry) => entry.hour !== hour);
+
+      this.trafficLogGroups = this.trafficLogGroups.filter(
+        (group) => !group.some((entry) => entry.hour === hour)
+      );
     },
     async addTrafficLogEntry(body) {
       const { data } = await api.post("/traffic-log", body);
-      const slot = this.trafficLog.find((element) => {
+      const entry = this.trafficLog.find((element) => {
         return (
-          element.entry.dow === data.dow &&
-          element.entry.hour === data.hour &&
-          element.entry.slot === data.slot
+          element.dow === data.dow &&
+          element.hour === data.hour &&
+          element.slot === data.slot
         );
       });
-      Object.assign(slot.entry, data);
+      Object.assign(entry, data);
+    },
+  },
+  persist: {
+    paths: ["trafficLog", "trafficLogGroups"],
+    afterRestore: ({ store }) => {
+      updateTrafficLog(store);
+      setInterval(updateTrafficLog, TRAFFIC_LOG_POLLING_INTERVAL, store);
     },
   },
 });

--- a/client/src/playlist/store.js
+++ b/client/src/playlist/store.js
@@ -150,14 +150,14 @@ export const usePlaylistStore = defineStore("playlist", {
     },
     async addTrafficLogEntry(body) {
       const { data } = await api.post("/traffic-log", body);
-      const entry = this.trafficLog.find((element) => {
+      const slot = this.trafficLog.find((element) => {
         return (
-          element.dow === data.dow &&
-          element.hour === data.hour &&
-          element.slot === data.slot
+          element.entry.dow === data.dow &&
+          element.entry.hour === data.hour &&
+          element.entry.slot === data.slot
         );
       });
-      Object.assign(entry, data);
+      Object.assign(slot.entry, data);
     },
   },
 });

--- a/client/src/playlist/store.js
+++ b/client/src/playlist/store.js
@@ -121,14 +121,17 @@ export const usePlaylistStore = defineStore("playlist", {
 
       let grouping = false;
       let groups = [];
-      for (let i = 0; i < slots.length - 1; i++) {
-        const entry = slots[i].entry;
-        const nextEntry = slots[i + 1].entry;
-
+      slots.forEach((slot, i) => {
+        const entry = slot.entry;
+        
         if (grouping) {
           groups.at(-1).push(entry);
         }
+        if (i === slots.length - 1) {
+          return;
+        }
 
+        const nextEntry = slots[i + 1].entry;
         if (entry.spot && nextEntry?.spot) {
           const slotTime = entry.hour * 60 + entry.slot;
           const nextSlotTime = nextEntry.hour * 60 + nextEntry.slot;
@@ -142,7 +145,7 @@ export const usePlaylistStore = defineStore("playlist", {
             grouping = false;
           }
         }
-      }
+      });
 
       this.trafficLog = slots;
       this.trafficLogGroups = groups;

--- a/client/src/traffic-log/store.js
+++ b/client/src/traffic-log/store.js
@@ -1,7 +1,6 @@
 import { defineStore } from "pinia";
 import { api } from "../services/api.service";
 
-
 function sortSpotsByTitle(a, b) {
   if (a.title === b.title || !a.title || !b.title) {
     return 0;


### PR DESCRIPTION
This work persists the retrieved traffic log entries on the cilent, including the random copy provided by the API.

The initial iteration of the /traffic-log endpoint tried to be as simple as possible for the client to fetch once each time the traffic log is first displayed. It provided the next three hours of existing or required entries, including a bit of random copy to read for each slot not yet marked as read. Fetching it each time meant the randomization also re-ran each time the app was refreshed, which could cause issues for DJs that might've been preparing to play one audio file and suddenly get told by NextUp to play another.

Persisting the retrieved entries also required a little more state management to be built into the client. It now checks every minute to see whether it needs new entries and can forget about entries from the past hour. 

And now that the client is retrieving entries an hour at a time, I simplified the code in the TrafficLogService since it's only retrieving spots and copy for one hour's worth of slots at a time instead of three.


