### PR TITLE
Prevent repeat copy with greylist

### DIFF
--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -1,3 +1,10 @@
 module.exports = {
+  CURRENT_TAGS: [
+    "local_current",
+    "local_classic",
+    "heavy_rotation",
+    "light_rotation",
+    "clean",
+  ],
   SPOT__VALID_SLOTS: [0, 12, 13, 24, 25, 30, 36, 37, 48, 49, 54, 55],
 };

--- a/app/db/migrations/remove-old-tags.js
+++ b/app/db/migrations/remove-old-tags.js
@@ -1,0 +1,35 @@
+const { Album } = require("../../models");
+const { datastore } = require("../../db");
+
+const oldTags = [
+  "EP",
+  "Disc 1",
+  "Disc 2",
+  "Disc 3",
+  "Disc 4",
+  "Disc 5",
+];
+
+async function up() {
+  for (const tag of oldTags) {
+    const query = Album.query()
+      .filter("revoked", false)
+      .filter("current_tags", tag);
+    const { entities: albums } = await query.run({
+      format: "ENTITY",
+      wrapNumbers: {
+        integerTypeCastFunction: datastore.int,
+        properties: ["album_id"],
+      },
+    });
+    
+    for (const album of albums) {
+      console.log(album.album_id.value, album.title);
+      const index = album.current_tags.findIndex((item) => item === tag);
+      album.current_tags.splice(index, 1);      
+      await album.save();
+    }
+  }
+}
+
+up();

--- a/app/models/album.model.js
+++ b/app/models/album.model.js
@@ -1,5 +1,6 @@
 const gstore = require("../db").gstore;
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 function validateCurrentTags(obj, validator, validTags) {
   if (Array.isArray(obj)) {
@@ -28,20 +29,7 @@ const albumSchema = new Schema({
     type: Array,
     validate: {
       rule: validateCurrentTags,
-      args: [
-        [
-          "local_current",
-          "local_classic",
-          "heavy_rotation",
-          "light_rotation",
-          "clean",
-          "ep",
-          "Disc 1",
-          "Disc 2",
-          "Disc 3",
-          "Disc 4",
-        ],
-      ],
+      args: [CURRENT_TAGS],
     },
     default: [],
   },

--- a/app/models/artist.model.js
+++ b/app/models/artist.model.js
@@ -1,5 +1,6 @@
 const gstore = require("../db").gstore;
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 function validateCurrentTags(obj, validator, validTags) {
   if (Array.isArray(obj)) {
@@ -14,9 +15,7 @@ const artistSchema = new Schema({
     type: Array,
     validate: {
       rule: validateCurrentTags,
-      args: [
-        ["local_current", "local_classic", "heavy_rotation", "light_rotation"],
-      ],
+      args: [CURRENT_TAGS],
     },
   },
   image: { type: String },

--- a/app/models/crateItem.model.js
+++ b/app/models/crateItem.model.js
@@ -1,5 +1,6 @@
 const gstore = require("../db").gstore;
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 function validateCategories(obj, validator, validTags) {
   if (Array.isArray(obj)) {
@@ -21,9 +22,7 @@ const crateItemSchema = new Schema({
     default: [],
     validate: {
       rule: validateCategories,
-      args: [
-        ["local_current", "local_classic", "heavy_rotation", "light_rotation"],
-      ],
+      args: [CURRENT_TAGS],
     },
   },
 });

--- a/app/models/playlistevent.model.js
+++ b/app/models/playlistevent.model.js
@@ -1,5 +1,6 @@
 const { datastore, gstore, getPlaylistKey } = require("../db");
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 let PLAYLIST_KEY;
 
@@ -18,9 +19,7 @@ const playlistEventSchema = new Schema({
     type: Array,
     validate: {
       rule: validateArray,
-      args: [
-        ["local_current", "local_classic", "heavy_rotation", "light_rotation"],
-      ],
+      args: [CURRENT_TAGS],
     },
   },
   class: {

--- a/app/routes/api/album/validators.js
+++ b/app/routes/api/album/validators.js
@@ -1,14 +1,10 @@
 const { body, query, param } = require("express-validator");
+const { CURRENT_TAGS } = require("../../../config/constants");
 
 module.exports = {
   validateLimit: query("limit").optional().isInt({ min: 1, max: 100 }),
   validateOffset: query("offset").optional().isInt(),
-  validateTag: query("tag").isIn([
-    "heavy_rotation",
-    "light_rotation",
-    "local_current",
-    "local_classic",
-  ]),
+  validateTag: query("tag").isIn(CURRENT_TAGS),
   validateTags: body("tags").isArray(),
   validateTimestamp: query("timestamp").optional().isInt(),
   validateTrackNum: param("track_num").isInt({ min: 0 }).toInt(),

--- a/app/routes/api/traffic-log/controller.js
+++ b/app/routes/api/traffic-log/controller.js
@@ -7,7 +7,8 @@ module.exports = {
       const hour = Number.isInteger(req.query.hour)
         ? req.query.hour
         : DateService.currentChicagoHour();
-      const log = await TrafficLogService.getLog(dow, hour);
+      const greylist = req.query.greylist || [];
+      const log = await TrafficLogService.getLog(dow, hour, greylist);
       res.json(log);
     } catch (error) {
       next(error);

--- a/app/routes/api/traffic-log/router.js
+++ b/app/routes/api/traffic-log/router.js
@@ -4,11 +4,19 @@ const {
   validateStart,
   validateDow,
   validateHour,
+  validateGreylist,
 } = require("./validators");
 const { checkErrors } = require("../errors");
 const controller = require("./controller");
 
-router.get("/", validateDow, validateHour, checkErrors, controller.getLog);
+router.get(
+  "/",
+  validateDow,
+  validateHour,
+  validateGreylist,
+  checkErrors,
+  controller.getLog
+);
 
 router.post("/", controller.addEntry);
 

--- a/app/routes/api/traffic-log/validators.js
+++ b/app/routes/api/traffic-log/validators.js
@@ -3,6 +3,18 @@ const { query } = require("express-validator");
 module.exports = {
   validateDow: query("dow").optional().isInt({ min: 1, max: 7 }).toInt(),
   validateHour: query("hour").optional().isInt({ min: 0, max: 23 }).toInt(),
+  validateGreylist: query("greylist")
+    .optional()
+    .custom((value) => {
+      if (typeof value === "string") {
+        return true;
+      }
+      if (Array.isArray(value)) {
+        return value.every((id) => typeof id === "string");
+      }
+      throw new Error("greylist must be a string or an array of strings");
+    })
+    .toArray(),
   validateStart: query("start").isISO8601(),
   validateEnd: query("end").isISO8601(),
 };

--- a/app/routes/tasks/tasks.controller.js
+++ b/app/routes/tasks/tasks.controller.js
@@ -7,12 +7,7 @@ const {
   SearchService,
 } = require("../../services");
 const levenshtein = require("js-levenshtein");
-const validTags = [
-  "local_current",
-  "local_classic",
-  "heavy_rotation",
-  "light_rotation",
-];
+const { CURRENT_TAGS } = require("../../config/constants");
 
 async function updateIndexWithAlbumArtist(artist) {
   await SearchService.update(
@@ -197,7 +192,7 @@ async function updateFreeformRotationPlays(req, res) {
             playlistTrack.artist = album.album_artist.__key;
             playlistTrack.track = track.__key;
             playlistTrack.categories = album.current_tags.filter((tag) =>
-              validTags.includes(tag)
+              CURRENT_TAGS.includes(tag)
             );
             const { error } = playlistTrack.validate();
             if (!error) {

--- a/app/services/trafficLog.service.js
+++ b/app/services/trafficLog.service.js
@@ -58,16 +58,31 @@ async function getActiveCopyForSpot(key) {
     }),
   ];
   const results = await Promise.all(promises);
-  return results.reduce(
+  const copy = results.reduce(
     (previous, current) => previous.concat(current.entities),
     []
   );
+  const spotId = parseInt(key.id, 10);
+  return { spotId, copy };
 }
 
-async function getActiveCopy(spotKeys) {
-  const promises = spotKeys.map(async (key) => await getActiveCopyForSpot(key));
-  const copy = await Promise.all(promises);
-  return copy.flat();
+async function getActiveSpotsAndCopy(spotKeys) {
+  const spotIds = spotKeys.map((key) => parseInt(key.id, 10));
+  const spots = await Spot.get(spotIds);
+  const activeSpots = spots.filter((spot) => spot.active && !spot.deleted);
+  const activeSpotKeys = activeSpots.map((spot) => spot.entityKey);
+  const promises = activeSpotKeys.map(
+    async (key) => await getActiveCopyForSpot(key)
+  );
+  const allCopy = await Promise.all(promises);
+  const spotsAndCopy = allCopy.reduce((acc, { spotId, copy }) => {
+    acc[spotId] = {
+      copy,
+      spot: spots.find((spot) => spot.id == spotId),
+    };
+    return acc;
+  }, {});
+  return spotsAndCopy;
 }
 
 function copyIsRunning(copy) {
@@ -90,36 +105,6 @@ function copyIsRunning(copy) {
   return started && !expired;
 }
 
-function findExistingEntryForConstraint(entries, constraint) {
-  return entries.find((entry) => {
-    return entry.scheduled.name == constraint.id;
-  });
-}
-
-async function getRandomCopyForConstraint(copy, constraint, greylist) {
-  if (!constraint.spots) {
-    return;
-  }
-
-  const spotIds = constraint.spots.map((spot) => spot.id);
-  const runningCopy = copy
-    .filter((item) => spotIds.includes(item.spot.id))
-    .filter(copyIsRunning);
-
-  let validCopy = runningCopy;
-  if (runningCopy.length > 1) {
-    validCopy = runningCopy.filter((copy) => !greylist.includes(copy.id));
-  }
-
-  if (validCopy.length) {
-    const randomIndex = Math.floor(Math.random() * validCopy.length);
-    const randomCopy = validCopy[randomIndex];
-    const spot = await Spot.get(parseInt(randomCopy.spot.id, 10));
-    randomCopy.spot = spot.plain({ showKey: true });
-    return randomCopy;
-  }
-}
-
 function buildEntry(constraint, copy) {
   let spot;
   if (copy) {
@@ -137,41 +122,47 @@ function buildEntry(constraint, copy) {
   return entry.plain();
 }
 
-async function buildEntries(existingEntries, constraints, copy, greylist) {
-  return Promise.all(
-    constraints.map(async (constraint) => {
-      const existingEntryForConstraint = findExistingEntryForConstraint(
-        existingEntries,
-        constraint
+function buildEntries(existingEntries, constraints, spots, greylist) {
+  const entries = [];
+  for (const constraint of constraints) {
+    if (!constraint.spots?.length) {
+      continue;
+    }
+    
+    for (const spot of constraint.spots) {
+      const entry = existingEntries.find(
+        (entry) =>
+          entry.scheduled.name == constraint.id && entry.spot.id == spot.id
       );
 
-      if (existingEntryForConstraint) {
-        return existingEntryForConstraint;
+      if (entry) {
+        entries.push(entry);
       } else {
-        const randomCopy = await getRandomCopyForConstraint(
-          copy,
-          constraint,
-          greylist
-        );
-        return buildEntry(constraint, randomCopy);
+        const copyForSpot = spots[spot.id].copy.filter(copyIsRunning);
+        if (copyForSpot.length) {
+          let validCopy = copyForSpot;
+          if (copyForSpot.length > 1) {
+            validCopy = copyForSpot.filter((copy) => !greylist.includes(copy.id));
+          }
+          const randomIndex = Math.floor(Math.random() * validCopy.length);
+          const randomCopy = validCopy[randomIndex];
+          randomCopy.spot = spots[spot.id].spot.plain({ showKey: true });
+          entries.push(buildEntry(constraint, randomCopy));
+        }
       }
-    })
-  );
+    }
+  }
+
+  return entries;
 }
 
 async function getLog(dow, hour, greylist) {
   const existingEntries = await getTrafficLogEntries(dow, hour);
   const constraints = await getConstraints(dow, hour);
   const spotKeys = uniqueSpotKeysAtConstraints(constraints);
-  const copy = await getActiveCopy(spotKeys);
-  const entries = await buildEntries(
-    existingEntries,
-    constraints,
-    copy,
-    greylist
-  );
-  const entriesWithASpot = entries.filter((entry) => entry.spot);
-  return entriesWithASpot;
+  const spots = await getActiveSpotsAndCopy(spotKeys);
+  const entries = buildEntries(existingEntries, constraints, spots, greylist);
+  return entries;
 }
 
 function checkForKey(prop, value) {

--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -95,7 +95,7 @@ export default {
     },
     selectedIndexInGroup() {
       return this.selectedGroup?.findIndex(
-        (entry) => this.selected.scheduled.name === entry.scheduled.name
+        (entry) => this.selected.spot_copy.id === entry.spot_copy.id
       );
     },
     previousInGroup() {


### PR DESCRIPTION
- Accept an array of SpotCopy ids as a greylist of copy to avoid when generating the traffic log for a given hour
- Remove those ids from the list of options to choose from randomly unless it's the only option for that slot