### PR TITLE
Remove old album tags

### DIFF
--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -1,3 +1,9 @@
 module.exports = {
+  CURRENT_TAGS: [
+    "local_current",
+    "local_classic",
+    "heavy_rotation",
+    "light_rotation",
+  ],
   SPOT__VALID_SLOTS: [0, 12, 13, 24, 25, 30, 36, 37, 48, 49, 54, 55],
 };

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -4,6 +4,7 @@ module.exports = {
     "local_classic",
     "heavy_rotation",
     "light_rotation",
+    "clean",
   ],
   SPOT__VALID_SLOTS: [0, 12, 13, 24, 25, 30, 36, 37, 48, 49, 54, 55],
 };

--- a/app/db/migrations/remove-old-tags.js
+++ b/app/db/migrations/remove-old-tags.js
@@ -2,7 +2,6 @@ const { Album } = require("../../models");
 const { datastore } = require("../../db");
 
 const oldTags = [
-  "clean",
   "EP",
   "Disc 1",
   "Disc 2",

--- a/app/db/migrations/remove-old-tags.js
+++ b/app/db/migrations/remove-old-tags.js
@@ -1,0 +1,36 @@
+const { Album } = require("../../models");
+const { datastore } = require("../../db");
+
+const oldTags = [
+  "clean",
+  "EP",
+  "Disc 1",
+  "Disc 2",
+  "Disc 3",
+  "Disc 4",
+  "Disc 5",
+];
+
+async function up() {
+  for (const tag of oldTags) {
+    const query = Album.query()
+      .filter("revoked", false)
+      .filter("current_tags", tag);
+    const { entities: albums } = await query.run({
+      format: "ENTITY",
+      wrapNumbers: {
+        integerTypeCastFunction: datastore.int,
+        properties: ["album_id"],
+      },
+    });
+    
+    for (const album of albums) {
+      console.log(album.album_id.value, album.title);
+      const index = album.current_tags.findIndex((item) => item === tag);
+      album.current_tags.splice(index, 1);      
+      await album.save();
+    }
+  }
+}
+
+up();

--- a/app/models/album.model.js
+++ b/app/models/album.model.js
@@ -1,5 +1,6 @@
 const gstore = require("../db").gstore;
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 function validateCurrentTags(obj, validator, validTags) {
   if (Array.isArray(obj)) {
@@ -28,20 +29,7 @@ const albumSchema = new Schema({
     type: Array,
     validate: {
       rule: validateCurrentTags,
-      args: [
-        [
-          "local_current",
-          "local_classic",
-          "heavy_rotation",
-          "light_rotation",
-          "clean",
-          "ep",
-          "Disc 1",
-          "Disc 2",
-          "Disc 3",
-          "Disc 4",
-        ],
-      ],
+      args: [CURRENT_TAGS],
     },
     default: [],
   },

--- a/app/models/artist.model.js
+++ b/app/models/artist.model.js
@@ -1,5 +1,6 @@
 const gstore = require("../db").gstore;
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 function validateCurrentTags(obj, validator, validTags) {
   if (Array.isArray(obj)) {
@@ -14,9 +15,7 @@ const artistSchema = new Schema({
     type: Array,
     validate: {
       rule: validateCurrentTags,
-      args: [
-        ["local_current", "local_classic", "heavy_rotation", "light_rotation"],
-      ],
+      args: [CURRENT_TAGS],
     },
   },
   image: { type: String },

--- a/app/models/crateItem.model.js
+++ b/app/models/crateItem.model.js
@@ -1,5 +1,6 @@
 const gstore = require("../db").gstore;
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 function validateCategories(obj, validator, validTags) {
   if (Array.isArray(obj)) {
@@ -21,9 +22,7 @@ const crateItemSchema = new Schema({
     default: [],
     validate: {
       rule: validateCategories,
-      args: [
-        ["local_current", "local_classic", "heavy_rotation", "light_rotation"],
-      ],
+      args: [CURRENT_TAGS],
     },
   },
 });

--- a/app/models/playlistevent.model.js
+++ b/app/models/playlistevent.model.js
@@ -1,5 +1,6 @@
 const { datastore, gstore, getPlaylistKey } = require("../db");
 const { Schema } = gstore;
+const { CURRENT_TAGS } = require("../config/constants");
 
 let PLAYLIST_KEY;
 
@@ -18,9 +19,7 @@ const playlistEventSchema = new Schema({
     type: Array,
     validate: {
       rule: validateArray,
-      args: [
-        ["local_current", "local_classic", "heavy_rotation", "light_rotation"],
-      ],
+      args: [CURRENT_TAGS],
     },
   },
   class: {

--- a/app/routes/api/album/validators.js
+++ b/app/routes/api/album/validators.js
@@ -1,14 +1,10 @@
 const { body, query, param } = require("express-validator");
+const { CURRENT_TAGS } = require("../../../config/constants");
 
 module.exports = {
   validateLimit: query("limit").optional().isInt({ min: 1, max: 100 }),
   validateOffset: query("offset").optional().isInt(),
-  validateTag: query("tag").isIn([
-    "heavy_rotation",
-    "light_rotation",
-    "local_current",
-    "local_classic",
-  ]),
+  validateTag: query("tag").isIn(CURRENT_TAGS),
   validateTags: body("tags").isArray(),
   validateTimestamp: query("timestamp").optional().isInt(),
   validateTrackNum: param("track_num").isInt({ min: 0 }).toInt(),

--- a/app/routes/tasks/tasks.controller.js
+++ b/app/routes/tasks/tasks.controller.js
@@ -7,12 +7,7 @@ const {
   SearchService,
 } = require("../../services");
 const levenshtein = require("js-levenshtein");
-const validTags = [
-  "local_current",
-  "local_classic",
-  "heavy_rotation",
-  "light_rotation",
-];
+const { CURRENT_TAGS } = require("../../config/constants");
 
 async function updateIndexWithAlbumArtist(artist) {
   await SearchService.update(
@@ -197,7 +192,7 @@ async function updateFreeformRotationPlays(req, res) {
             playlistTrack.artist = album.album_artist.__key;
             playlistTrack.track = track.__key;
             playlistTrack.categories = album.current_tags.filter((tag) =>
-              validTags.includes(tag)
+              CURRENT_TAGS.includes(tag)
             );
             const { error } = playlistTrack.validate();
             if (!error) {

--- a/app/services/spot.service.js
+++ b/app/services/spot.service.js
@@ -73,7 +73,7 @@ async function updateSpot(id, data) {
     const current = await getConstraintsForSpot(spotKey);
     const currentIds = current.map((constraint) => constraint.id);
     const removed = currentIds.filter((id) => !data.constraints.includes(id));
-    const added = data.constraints.filter((id) => !currentIds.includes(id));    
+    const added = data.constraints.filter((id) => !currentIds.includes(id));
 
     const addPromises = added.map(async function (id) {
       return addSpotToConstraint(spotKey, id, transaction);


### PR DESCRIPTION
- Strip "Disc _X_" and "EP" tags from albums
- Allow "clean" as a valid tag for back end validation (including playlist events)
- Move tags into shared constants file to make them easier to manage in future PRs