### PR TITLE
Handle multiple spots in one slot

### DIFF
--- a/app/routes/api/traffic-log/controller.js
+++ b/app/routes/api/traffic-log/controller.js
@@ -7,7 +7,8 @@ module.exports = {
       const hour = Number.isInteger(req.query.hour)
         ? req.query.hour
         : DateService.currentChicagoHour();
-      const log = await TrafficLogService.getLog(dow, hour);
+      const greylist = req.query.greylist || [];
+      const log = await TrafficLogService.getLog(dow, hour, greylist);
       res.json(log);
     } catch (error) {
       next(error);

--- a/app/routes/api/traffic-log/router.js
+++ b/app/routes/api/traffic-log/router.js
@@ -4,11 +4,19 @@ const {
   validateStart,
   validateDow,
   validateHour,
+  validateGreylist,
 } = require("./validators");
 const { checkErrors } = require("../errors");
 const controller = require("./controller");
 
-router.get("/", validateDow, validateHour, checkErrors, controller.getLog);
+router.get(
+  "/",
+  validateDow,
+  validateHour,
+  validateGreylist,
+  checkErrors,
+  controller.getLog
+);
 
 router.post("/", controller.addEntry);
 

--- a/app/routes/api/traffic-log/validators.js
+++ b/app/routes/api/traffic-log/validators.js
@@ -3,6 +3,18 @@ const { query } = require("express-validator");
 module.exports = {
   validateDow: query("dow").optional().isInt({ min: 1, max: 7 }).toInt(),
   validateHour: query("hour").optional().isInt({ min: 0, max: 23 }).toInt(),
+  validateGreylist: query("greylist")
+    .optional()
+    .custom((value) => {
+      if (typeof value === "string") {
+        return true;
+      }
+      if (Array.isArray(value)) {
+        return value.every((id) => typeof id === "string");
+      }
+      throw new Error("greylist must be a string or an array of strings");
+    })
+    .toArray(),
   validateStart: query("start").isISO8601(),
   validateEnd: query("end").isISO8601(),
 };

--- a/app/services/trafficLog.service.js
+++ b/app/services/trafficLog.service.js
@@ -58,16 +58,31 @@ async function getActiveCopyForSpot(key) {
     }),
   ];
   const results = await Promise.all(promises);
-  return results.reduce(
+  const copy = results.reduce(
     (previous, current) => previous.concat(current.entities),
     []
   );
+  const spotId = parseInt(key.id, 10);
+  return { spotId, copy };
 }
 
-async function getActiveCopy(spotKeys) {
-  const promises = spotKeys.map(async (key) => await getActiveCopyForSpot(key));
-  const copy = await Promise.all(promises);
-  return copy.flat();
+async function getActiveSpotsAndCopy(spotKeys) {
+  const spotIds = spotKeys.map((key) => parseInt(key.id, 10));
+  const spots = await Spot.get(spotIds);
+  const activeSpots = spots.filter((spot) => spot.active && !spot.deleted);
+  const activeSpotKeys = activeSpots.map((spot) => spot.entityKey);
+  const promises = activeSpotKeys.map(
+    async (key) => await getActiveCopyForSpot(key)
+  );
+  const allCopy = await Promise.all(promises);
+  const spotsAndCopy = allCopy.reduce((acc, { spotId, copy }) => {
+    acc[spotId] = {
+      copy,
+      spot: spots.find((spot) => spot.id == spotId),
+    };
+    return acc;
+  }, {});
+  return spotsAndCopy;
 }
 
 function copyIsRunning(copy) {
@@ -90,33 +105,6 @@ function copyIsRunning(copy) {
   return started && !expired;
 }
 
-function findExistingEntryForConstraint(entries, constraint) {
-  return entries.find((entry) => {
-    return entry.scheduled.name == constraint.id;
-  });
-}
-
-async function getRandomCopyForConstraint(copy, constraint) {
-  if (!constraint.spots) {
-    return;
-  }
-
-  const spotIds = constraint.spots.map((spot) => spot.id);
-  const copyForConstraint = copy.filter((item) =>
-    spotIds.includes(item.spot.id)
-  );
-  const runningCopy = copyForConstraint.filter(copyIsRunning);
-  let randomCopy;
-  let spot;
-  if (runningCopy.length) {
-    const randomIndex = Math.floor(Math.random() * runningCopy.length);
-    randomCopy = runningCopy[randomIndex];
-    spot = await Spot.get(parseInt(randomCopy.spot.id, 10));
-    randomCopy.spot = spot.plain({ showKey: true });
-  }
-  return randomCopy;
-}
-
 function buildEntry(constraint, copy) {
   let spot;
   if (copy) {
@@ -134,32 +122,43 @@ function buildEntry(constraint, copy) {
   return entry.plain();
 }
 
-async function buildEntries(existingEntries, constraints, copy) {
-  return Promise.all(
-    constraints.map(async (constraint) => {
-      const existingEntryForConstraint = findExistingEntryForConstraint(
-        existingEntries,
-        constraint
+function buildEntries(existingEntries, constraints, spots) {
+  const entries = [];
+  for (const constraint of constraints) {
+    if (!constraint.spots?.length) {
+      continue;
+    }
+    
+    for (const spot of constraint.spots) {
+      const entry = existingEntries.find(
+        (entry) =>
+          entry.scheduled.name == constraint.id && entry.spot.id == spot.id
       );
 
-      if (existingEntryForConstraint) {
-        return existingEntryForConstraint;
+      if (entry) {
+        entries.push(entry);
       } else {
-        const randomCopy = await getRandomCopyForConstraint(copy, constraint);
-        return buildEntry(constraint, randomCopy);
+        const copyForSpot = spots[spot.id].copy.filter(copyIsRunning);
+        if (copyForSpot.length) {
+          const randomIndex = Math.floor(Math.random() * copyForSpot.length);
+          const randomCopy = copyForSpot[randomIndex];
+          randomCopy.spot = spots[spot.id].spot.plain({ showKey: true });
+          entries.push(buildEntry(constraint, randomCopy));
+        }
       }
-    })
-  );
+    }
+  }
+
+  return entries;
 }
 
 async function getLog(dow, hour) {
   const existingEntries = await getTrafficLogEntries(dow, hour);
   const constraints = await getConstraints(dow, hour);
   const spotKeys = uniqueSpotKeysAtConstraints(constraints);
-  const copy = await getActiveCopy(spotKeys);
-  const entries = await buildEntries(existingEntries, constraints, copy);
-  const entriesWithASpot = entries.filter((entry) => entry.spot);
-  return entriesWithASpot;
+  const spots = await getActiveSpotsAndCopy(spotKeys);
+  const entries = buildEntries(existingEntries, constraints, spots);
+  return entries;
 }
 
 function checkForKey(prop, value) {

--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -95,7 +95,7 @@ export default {
     },
     selectedIndexInGroup() {
       return this.selectedGroup?.findIndex(
-        (entry) => this.selected.scheduled.name === entry.scheduled.name
+        (entry) => this.selected.spot_copy.id === entry.spot_copy.id
       );
     },
     previousInGroup() {


### PR DESCRIPTION
Return an entry stub for each active spot in a slot with running copy (instead of combining their running copy into a single pool and randomly picking from that)