### PR TITLE
Avoid repeat copy from previous hour

### DIFF
--- a/app/routes/api/traffic-log/controller.js
+++ b/app/routes/api/traffic-log/controller.js
@@ -7,7 +7,8 @@ module.exports = {
       const hour = Number.isInteger(req.query.hour)
         ? req.query.hour
         : DateService.currentChicagoHour();
-      const log = await TrafficLogService.getLog(dow, hour);
+      const greylist = req.query.greylist || [];
+      const log = await TrafficLogService.getLog(dow, hour, greylist);
       res.json(log);
     } catch (error) {
       next(error);

--- a/app/routes/api/traffic-log/router.js
+++ b/app/routes/api/traffic-log/router.js
@@ -4,11 +4,19 @@ const {
   validateStart,
   validateDow,
   validateHour,
+  validateGreylist,
 } = require("./validators");
 const { checkErrors } = require("../errors");
 const controller = require("./controller");
 
-router.get("/", validateDow, validateHour, checkErrors, controller.getLog);
+router.get(
+  "/",
+  validateDow,
+  validateHour,
+  validateGreylist,
+  checkErrors,
+  controller.getLog
+);
 
 router.post("/", controller.addEntry);
 

--- a/app/routes/api/traffic-log/validators.js
+++ b/app/routes/api/traffic-log/validators.js
@@ -3,6 +3,18 @@ const { query } = require("express-validator");
 module.exports = {
   validateDow: query("dow").optional().isInt({ min: 1, max: 7 }).toInt(),
   validateHour: query("hour").optional().isInt({ min: 0, max: 23 }).toInt(),
+  validateGreylist: query("greylist")
+    .optional()
+    .custom((value) => {
+      if (typeof value === "string") {
+        return true;
+      }
+      if (Array.isArray(value)) {
+        return value.every((id) => typeof id === "string");
+      }
+      throw new Error("greylist must be a string or an array of strings");
+    })
+    .toArray(),
   validateStart: query("start").isISO8601(),
   validateEnd: query("end").isISO8601(),
 };


### PR DESCRIPTION
• Accept an array of SpotCopy ids as a greylist of copy to avoid when generating the traffic log for a given hour
• Remove those ids from the list of options to choose from randomly unless it's the only option for that slot