### PR TITLE
Watch for new track and reset state

### DIFF
--- a/client/src/components/music/PlayButton.vue
+++ b/client/src/components/music/PlayButton.vue
@@ -91,6 +91,21 @@ export default {
       playNotes: "",
     };
   },
+  created() {
+    /* 
+      use value passed in from props
+      if a DJ already added notes in their crate
+    */
+    this.playNotes = this.notes;
+  },
+  watch: {    
+    track() {
+      this.added = false;
+      this.adding = false;  
+      this.error = false;
+      this.playNotes = this.notes;
+    },
+  },
   computed: {
     ...mapStores(usePlaylistStore),
     trackOrAlbumArtist() {
@@ -143,13 +158,6 @@ export default {
         track: this.track,
       };
     },
-  },
-  created() {
-    /* 
-      use value passed in from props
-      if a DJ already added notes in their crate
-    */
-    this.playNotes = this.notes;
   },
   methods: {
     async addToPlaylist() {


### PR DESCRIPTION
# Steps to reproduce
1. Put two library tracks or two custom tracks in a row in your crate (the "two items")
2. Go to the playlist and go "on air"
3. Return to the crate
4. Add the first of the two items to the playlist so its label says "added"
5. Delete the first of the two items

# Previous behavior
Instead of a play button, the second item would now have the static label "added"

# Desired behavior
Second item has a play button