### PR TITLE
Cue anything from crate

### DIFF
--- a/client/src/components/CustomTrackForm.vue
+++ b/client/src/components/CustomTrackForm.vue
@@ -179,10 +179,10 @@ export default {
   beforeMount() {
     if (this.track) {
       this.item = {
-        track: this.track.track.title,
+        track: this.track.track?.title,
         artist: this.track.artist?.name || this.track.track_artist?.name,
-        album: this.track.album.title,
-        label: this.track.album.label,
+        album: this.track.album?.title,
+        label: this.track.album?.label,
         notes: this.track.notes,
         categories: this.track.categories,
       };

--- a/client/src/components/crates/AlbumItem.vue
+++ b/client/src/components/crates/AlbumItem.vue
@@ -13,7 +13,7 @@
     </div>
     <PlayButton
       :album="element.album"
-      :categories="element.album.current_tags"      
+      :categories="element.album.current_tags"
       type="freeform"
       class="mt-2 mt-md-0"
     />
@@ -28,7 +28,7 @@ import PlayButton from "../music/PlayButton.vue";
 
 export default {
   name: "AlbumItem",
-  components: { ArtistLink, CrateAlbumSpans, TagList, PlayButton, },
+  components: { ArtistLink, CrateAlbumSpans, TagList, PlayButton },
   props: {
     element: Object,
   },

--- a/client/src/components/crates/AlbumItem.vue
+++ b/client/src/components/crates/AlbumItem.vue
@@ -1,15 +1,22 @@
 <template>
-  <div>
-    <div class="mb-1">
-      <ArtistLink
-        v-if="element.artist"
-        :artist="element.artist"
-        class="fw-bold me-2"
-      />
-      <CrateAlbumSpans :album="element.album" />
+  <div class="d-flex flex-column flex-md-row">
+    <div class="d-flex flex-column flex-grow-1">
+      <div class="mb-1">
+        <ArtistLink
+          v-if="element.artist"
+          :artist="element.artist"
+          class="fw-bold me-2"
+        />
+        <CrateAlbumSpans :album="element.album" />
+      </div>
+      <TagList :tags="element.album.current_tags" :album="element.album" />
     </div>
-    <TagList :tags="element.album.current_tags" :album="element.album" />
-    <div class="text-muted">{{ element.notes }}</div>
+    <PlayButton
+      :album="element.album"
+      :categories="element.album.current_tags"      
+      type="freeform"
+      class="mt-2 mt-md-0"
+    />
   </div>
 </template>
 
@@ -17,10 +24,11 @@
 import CrateAlbumSpans from "./CrateAlbumSpans.vue";
 import ArtistLink from "../music/ArtistLink.vue";
 import TagList from "../music/TagList.vue";
+import PlayButton from "../music/PlayButton.vue";
 
 export default {
   name: "AlbumItem",
-  components: { ArtistLink, CrateAlbumSpans, TagList },
+  components: { ArtistLink, CrateAlbumSpans, TagList, PlayButton, },
   props: {
     element: Object,
   },

--- a/client/src/components/crates/ArtistItem.vue
+++ b/client/src/components/crates/ArtistItem.vue
@@ -3,11 +3,7 @@
     <div class="d-flex flex-column flex-grow-1">
       <ArtistLink :artist="element.artist" class="fw-bold" />
     </div>
-    <PlayButton
-      :artist="element.artist"
-      type="freeform"
-      class="mt-2 mt-md-0"
-    />
+    <PlayButton :artist="element.artist" type="freeform" class="mt-2 mt-md-0" />
   </div>
 </template>
 

--- a/client/src/components/crates/ArtistItem.vue
+++ b/client/src/components/crates/ArtistItem.vue
@@ -1,15 +1,23 @@
 <template>
-  <div>
-    <ArtistLink :artist="element.artist" class="fw-bold" />
+  <div class="d-flex flex-column flex-md-row">
+    <div class="d-flex flex-column flex-grow-1">
+      <ArtistLink :artist="element.artist" class="fw-bold" />
+    </div>
+    <PlayButton
+      :artist="element.artist"
+      type="freeform"
+      class="mt-2 mt-md-0"
+    />
   </div>
 </template>
 
 <script>
 import ArtistLink from "@/components/music/ArtistLink.vue";
+import PlayButton from "../music/PlayButton.vue";
 
 export default {
   name: "ArtistItem",
-  components: { ArtistLink },
+  components: { ArtistLink, PlayButton },
   props: {
     element: Object,
   },

--- a/client/src/components/music/PlayButton.vue
+++ b/client/src/components/music/PlayButton.vue
@@ -105,7 +105,7 @@ export default {
       if (cuedTrack.track?.__key) {
         return cuedTrack.track.__key.name === this.track?.__key?.name;
       }
-      
+
       const props = ["artist.name", "album.title", "track.title"];
       const cuedProps = _.pick(cuedTrack, props);
       const thisProps = _.pick(this, props);

--- a/client/src/components/music/PlayButton.vue
+++ b/client/src/components/music/PlayButton.vue
@@ -64,6 +64,7 @@
 <script>
 import { mapStores } from "pinia";
 import { usePlaylistStore } from "@/playlist/store";
+import { _ } from "lodash";
 
 export default {
   props: {
@@ -100,10 +101,15 @@ export default {
     },
     cued() {
       const cuedTrack = this.playlistStore.cuedTrack;
-      return (
-        cuedTrack?.track?.title === this.track?.title &&
-        cuedTrack?.album?.title === this.album?.title
-      );
+      if (!cuedTrack) return false;
+      if (cuedTrack.track?.__key) {
+        return cuedTrack.track.__key.name === this.track?.__key?.name;
+      }
+      
+      const props = ["artist.name", "album.title", "track.title"];
+      const cuedProps = _.pick(cuedTrack, props);
+      const thisProps = _.pick(this, props);
+      return _.isEqual(cuedProps, thisProps);
     },
     cuedLabel() {
       return this.cued ? "cued" : "cue";

--- a/client/src/components/music/PlayButton.vue
+++ b/client/src/components/music/PlayButton.vue
@@ -101,8 +101,8 @@ export default {
     cued() {
       const cuedTrack = this.playlistStore.cuedTrack;
       return (
-        cuedTrack?.track.title === this.track.title &&
-        cuedTrack?.album.title === this.album.title
+        cuedTrack?.track?.title === this.track?.title &&
+        cuedTrack?.album?.title === this.album?.title
       );
     },
     cuedLabel() {

--- a/client/src/components/music/PlayButton.vue
+++ b/client/src/components/music/PlayButton.vue
@@ -109,7 +109,7 @@ export default {
       return this.cued ? "cued" : "cue";
     },
     disabled() {
-      return this.added || this.error;
+      return this.added || this.error || !this.validForPlaylist;
     },
     playIcon() {
       if (this.added) {
@@ -142,6 +142,18 @@ export default {
         notes: this.playNotes,
         track: this.track,
       };
+    },
+    validForPlaylist() {
+      if (this.type === "track") {
+        return true;
+      }
+
+      return (
+        this.album?.title &&
+        this.artist?.name &&
+        this.track?.title &&
+        this.album?.label
+      );
     },
   },
   created() {

--- a/client/src/components/music/TrackList.vue
+++ b/client/src/components/music/TrackList.vue
@@ -35,7 +35,10 @@
                   <ArtistLink :artist="track.track_artist" />
                 </span>
               </div>
-              <div v-if="track.pronunciation" class="text-muted fw-light fst-italic">
+              <div
+                v-if="track.pronunciation"
+                class="text-muted fw-light fst-italic"
+              >
                 {{ track.pronunciation }}
               </div>
               <div class="mb-1">

--- a/client/src/playlist/components/CuedTrack.vue
+++ b/client/src/playlist/components/CuedTrack.vue
@@ -22,6 +22,7 @@
         icon="play"
         label="add to playlist"
         :loading="adding"
+        :disabled="!valid"
         @click="addToPlaylist"
       />
     </div>
@@ -54,6 +55,10 @@ export default {
     },
     editIcon() {
       return this.editing ? "check" : "edit";
+    },
+    valid() {
+      const cued = this.cuedTrack;
+      return cued.album && cued.album.label && cued.artist && cued.track;
     },
   },
   mixins: [playlistMixins],

--- a/client/src/playlist/components/PlaylistTrack.vue
+++ b/client/src/playlist/components/PlaylistTrack.vue
@@ -96,7 +96,7 @@ export default {
       return this.track.freeform_track_title || this.track.track?.title || "?";
     },
     album() {
-      return this.track.freeform_album_title || this.track.album?.title  || "?";
+      return this.track.freeform_album_title || this.track.album?.title || "?";
     },
     label() {
       return this.track.freeform_label || this.track.album?.label || "?";

--- a/client/src/playlist/components/PlaylistTrack.vue
+++ b/client/src/playlist/components/PlaylistTrack.vue
@@ -90,16 +90,16 @@ export default {
   computed: {
     ...mapStores(usePlaylistStore),
     artist() {
-      return this.track.freeform_artist_name || this.track.artist?.name;
+      return this.track.freeform_artist_name || this.track.artist?.name || "?";
     },
     title() {
-      return this.track.freeform_track_title || this.track.track?.title;
+      return this.track.freeform_track_title || this.track.track?.title || "?";
     },
     album() {
-      return this.track.freeform_album_title || this.track.album?.title;
+      return this.track.freeform_album_title || this.track.album?.title  || "?";
     },
     label() {
-      return this.track.freeform_label || this.track.album?.label;
+      return this.track.freeform_label || this.track.album?.label || "?";
     },
     freeform() {
       return !this.track.album?.album_id;

--- a/client/src/playlist/components/PlaylistTrack.vue
+++ b/client/src/playlist/components/PlaylistTrack.vue
@@ -90,16 +90,16 @@ export default {
   computed: {
     ...mapStores(usePlaylistStore),
     artist() {
-      return this.track.freeform_artist_name || this.track.artist.name;
+      return this.track.freeform_artist_name || this.track.artist?.name;
     },
     title() {
-      return this.track.freeform_track_title || this.track.track.title;
+      return this.track.freeform_track_title || this.track.track?.title;
     },
     album() {
-      return this.track.freeform_album_title || this.track.album.title;
+      return this.track.freeform_album_title || this.track.album?.title;
     },
     label() {
-      return this.track.freeform_label || this.track.album.label;
+      return this.track.freeform_label || this.track.album?.label;
     },
     freeform() {
       return !this.track.album?.album_id;

--- a/client/src/playlist/store.js
+++ b/client/src/playlist/store.js
@@ -58,7 +58,7 @@ async function updateTrafficLog(store) {
       store.removeEntries(weekday, hour);
     });
   }
-  
+
   if (updates.missing.length > 0) {
     await Promise.all(updates.missing.map(store.getEntries));
   }


### PR DESCRIPTION
The current DJDB allows artists and albums saved from the library as well as partially filled out custom crate items to be cued to the playlist. The form in the playlist is responsible for requiring and validating all the fields before allowing the cued data to be added to the playlist.

These changes allow for the same functionality and add the required checks and validation to support it.