### PR TITLE
Switch prop name from type to index

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -134,7 +134,7 @@ const routes = [
             },
             props: {
               filters: {
-                type: "artist",
+                index: "artist",
               },
               results: {
                 showAllLink: false,
@@ -158,7 +158,7 @@ const routes = [
             },
             props: {
               filters: {
-                type: "document",
+                index: "document",
               },
               results: {
                 showAllLink: false,


### PR DESCRIPTION
The issue originates in https://github.com/chirpradio/nextup/pull/120 where the `index` prop is set in the corresponding `AlbumFilters` and `TrackFilters` files where Artists and Reviews use the common `TermFilter` with an undefined value for `index`. 

The issue manifests in the UI by a limited result set when viewing all artist or review result and the title not being updated on the corresponding pages.

Compare the search term `king` on the everything results view with those returned in the album results:
![image](https://github.com/user-attachments/assets/5999cbdf-1744-49f9-9465-0faac41c3e2b)

![image](https://github.com/user-attachments/assets/94855e55-bd5c-44f6-bf22-87dd4b8162db)

Changing the filter prop from `type` to `index` appears to resolve the issue.