### PR TITLE
Authorize before displaying play button

### DIFF
--- a/client/src/components/music/PlayButton.vue
+++ b/client/src/components/music/PlayButton.vue
@@ -64,6 +64,7 @@
 <script>
 import { mapStores } from "pinia";
 import { usePlaylistStore } from "@/playlist/store";
+import { useAuthStore } from "@/stores/auth";
 
 export default {
   props: {
@@ -107,7 +108,7 @@ export default {
     },
   },
   computed: {
-    ...mapStores(usePlaylistStore),
+    ...mapStores(usePlaylistStore, useAuthStore),
     trackOrAlbumArtist() {
       return this.album.is_compilation
         ? this.track.track_artist
@@ -147,7 +148,7 @@ export default {
       }
     },
     onAir() {
-      return this.playlistStore.onAir;
+      return this.authStore.isAuthorized("playlist") && this.playlistStore.onAir;
     },
     freeformPlaylistTrack() {
       return {


### PR DESCRIPTION
# Steps to reproduce
* Log in as someone with playlist access
* Visit /playlist and turn on the "on air" toggle
* Log out
* Log in as someone without playlist access
* Visit a crate with tracks in it

# Observed behavior
Play button is displayed in the crate to the user without playlist access

# Desired behavior
Play button is not displayed in the crate to the user without playlist access