### PR TITLE
Clear last added to crate on log out

### DIFF
--- a/client/src/stores/crates.js
+++ b/client/src/stores/crates.js
@@ -111,6 +111,8 @@ export const useCratesStore = defineStore(
     watch(isAuthenticated, (value) => {
       if (value === true) {
         getCrates();
+      } else {
+        lastAddedTo.value = null;
       }
     });
 


### PR DESCRIPTION
# Steps to reproduce
1. Add an album, track, or artist to a crate
2. Log out
3. Log in as another user
4. Open the "add to crate" dropdown for an album, track, or artist

# Observed behavior
First user's last added to crate still shows up at the top of the list

# Desired behavior
First user's last added to crate does not show up at the top of the list