### PR TITLE
Cue custom track before adding to playlist

### DIFF
--- a/client/src/components/ModalDialog.vue
+++ b/client/src/components/ModalDialog.vue
@@ -25,6 +25,15 @@
             {{ cancelLabel }}
           </button>
           <button
+            v-if="!loading && showSecondaryBtn"
+            type="button"
+            class="btn btn-outline-chirp-red"
+            @click="secondaryAction"
+            :disabled="disabled"
+          >
+            {{ secondaryLabel }}
+          </button>
+          <button
             v-if="!loading"
             type="button"
             class="btn btn-chirp-red"
@@ -45,10 +54,11 @@ import { Modal } from "bootstrap";
 import RecordSpinner from "./RecordSpinner.vue";
 
 const CONFIRM = "confirm";
+const SECONDARY = "secondary";
 
 export default {
   components: { RecordSpinner },
-  emits: [CONFIRM],
+  emits: [CONFIRM, SECONDARY],
   props: {
     title: String,
     cancelLabel: {
@@ -58,6 +68,13 @@ export default {
     confirmLabel: {
       type: String,
       default: "confirm",
+    },
+    secondaryLabel: {
+      type: String,
+    },
+    showSecondaryBtn: {
+      type: Boolean,
+      default: false,
     },
     loading: {
       type: Boolean,
@@ -89,6 +106,9 @@ export default {
     },
     confirm() {
       this.$emit(CONFIRM);
+    },
+    secondaryAction() {
+      this.$emit(SECONDARY);
     },
   },
 };

--- a/client/src/playlist/components/AddTrackModal.vue
+++ b/client/src/playlist/components/AddTrackModal.vue
@@ -3,7 +3,10 @@
     ref="modal"
     title="Add track to playlist"
     confirmLabel="add to playlist"
-    @confirm="onConfirm"
+    @confirm="addToPlaylist"
+    :showSecondaryBtn="true"
+    secondaryLabel="cue track"
+    @secondary="cueTrack"
     :loading="adding"
     :error="error"
     :disabled="disabled"
@@ -39,7 +42,7 @@ export default {
     updateDisabled() {
       this.disabled = !this.$refs.form.checkValidity();
     },
-    async onConfirm() {
+    async addToPlaylist() {
       if (this.$refs.form.checkValidity()) {
         try {
           this.error = false;
@@ -55,6 +58,15 @@ export default {
         } finally {
           this.adding = false;
         }
+      }
+    },
+    cueTrack() {
+      if (this.$refs.form.checkValidity()) {
+        const item = this.$refs.form.item;
+        const track = this.convertCrateItemToFreeformTrack(item);
+        this.playlistStore.cue(track);
+        this.$refs.form.reset();
+        this.$refs.modal.hide();
       }
     },
   },


### PR DESCRIPTION
- Adds a new option for a secondary action on modals
- Uses that option to let DJs cue a custom track instead of adding it to the playlist immediately

<img width="929" alt="Screenshot 2025-04-27 at 11 48 31 AM" src="https://github.com/user-attachments/assets/b311c98a-4560-4862-bee3-753e0ff423df" />
