### PR TITLE
Clear playlist and traffic log polling on error

### DIFF
--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -123,6 +123,9 @@ export default {
       }
     },
   },
+  created() {
+    this.trafficLogStore.pollForEntries();
+  },
   mounted() {
     this.drawer = new Offcanvas(this.$refs.spot);
   },

--- a/client/src/playlist/playlistStore.js
+++ b/client/src/playlist/playlistStore.js
@@ -91,8 +91,8 @@ export const usePlaylistStore = defineStore("playlist", {
           },
         });
         this.rotationPlays = rotationPlays;
-      } catch (error) {
-        console.error(error);
+      } catch (error) {        
+        clearInterval(intervalID);
         intervalID = undefined;
       }
     },

--- a/client/src/playlist/playlistStore.js
+++ b/client/src/playlist/playlistStore.js
@@ -91,7 +91,7 @@ export const usePlaylistStore = defineStore("playlist", {
           },
         });
         this.rotationPlays = rotationPlays;
-      } catch (error) {        
+      } catch (error) {
         clearInterval(intervalID);
         intervalID = undefined;
       }


### PR DESCRIPTION
# Steps to reproduce
1. Open the playlist and go "on air"
2. Let the session expire (note: it's six hours in production, but for testing I reduced that to five minutes)

# Observed behavior
The application would continue to poll for rotation tracks added to the playlist and for traffic log updates

# Desired behavior
Polling stops until a user logs in again