### PR TITLE
Log out and log back in across tabs

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -11,10 +11,26 @@
 
 <script>
 import NavBar from "./components/NavBar.vue";
+import { mapStores } from "pinia";
+import { useAuthStore } from "./stores/auth";
+import api from "./services/api.service";
 
 export default {
   components: {
     NavBar,
+  },
+  computed: {
+    ...mapStores(useAuthStore),
+  },
+  watch: {
+    "authStore.isAuthenticated": function (newVal) {
+      if (newVal === true) {
+        api.setAuthorizationHeader(this.authStore.token);
+        this.$router.push(this.$route.query.redirect || "/");
+      } else {
+        this.$router.go();
+      }
+    },
   },
 };
 </script>

--- a/client/src/views/crates/CrateView.vue
+++ b/client/src/views/crates/CrateView.vue
@@ -201,12 +201,18 @@ export default {
     },
   },
   created: async function () {
-    this.loading = true;
-    await this.cratesStore.getCrate({ crateId: this.id });
-    await this.cratesStore.getCrateItems({
-      crateId: this.id,
-    });
-    this.loading = false;
+    try {
+      this.loading = true;
+      await this.cratesStore.getCrate({ crateId: this.id });
+      await this.cratesStore.getCrateItems({
+        crateId: this.id,
+      });
+      this.loading = false;
+    } catch (err) {
+      if (err.status === 403) {
+        this.$router.replace("/");
+      }
+    }
   },
   mounted() {
     deleteModal = new Modal(document.getElementById("deleteModal"));


### PR DESCRIPTION
- Watch for authentication changes at the app level and redirect accordingly if logged in or force a redirect to the log in page if logged out
- Catch the error state of redirecting to another user's crate and redirect home instead