### PR TITLE
Improve track results when searching terms across fields

### DIFF
--- a/app/services/search.service.js
+++ b/app/services/search.service.js
@@ -353,6 +353,7 @@ function buildFuzzyMultiMatch(term, fields) {
           query: term,
           operator: "AND",
           fields: fields,
+          type: "cross_fields",
           boost: 2,
         },
       },


### PR DESCRIPTION
- Intended to do a better job at suggesting **tracks** when combining multiple terms that could be in track name, artist name, or album title (e.g., "gary cars", "foggy velvet")
- Still falls back to a fuzzy match to catch typos or misspellings
- Doesn't change album or artist query logic