### PR TITLE
Markdown editor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "luxon": "^3.5.0",
+        "markdown-it": "^14.1.0",
         "pinia": "^2.1.7",
         "pinia-plugin-persistedstate": "^3.2.1",
         "pinia-shared-state": "^0.5.1",
@@ -1221,8 +1222,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -2930,6 +2930,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2984,6 +2993,29 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -3505,6 +3537,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4094,6 +4135,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "luxon": "^3.5.0",
+    "markdown-it": "^14.1.0",
     "pinia": "^2.1.7",
     "pinia-plugin-persistedstate": "^3.2.1",
     "pinia-shared-state": "^0.5.1",

--- a/client/src/components/music/AlbumDocuments.vue
+++ b/client/src/components/music/AlbumDocuments.vue
@@ -16,8 +16,8 @@
   />
   <div class="row">
     <label for="comment" class="form-label">Write a comment</label>
-    <div class="col-9">
-      <textarea id="comment" class="form-control" v-model="comment" />
+    <div class="col-9">      
+      <MarkdownEditor v-model="comment" />
     </div>
   </div>
   <LoadingButton
@@ -37,11 +37,13 @@ import DocumentFigure from "./DocumentFigure.vue";
 import { mapStores } from "pinia";
 import { useAuthStore } from "@/stores/auth";
 import { useDocumentsStore } from "../../stores/documents";
+import MarkdownEditor from "./MarkdownEditor.vue";
 
 export default {
   components: {
     DocumentFigure,
     LoadingButton,
+    MarkdownEditor,
   },
   data() {
     return {

--- a/client/src/components/music/AlbumDocuments.vue
+++ b/client/src/components/music/AlbumDocuments.vue
@@ -16,7 +16,7 @@
   />
   <div class="row">
     <label for="comment" class="form-label">Write a comment</label>
-    <div class="col-9">      
+    <div class="col-9">
       <MarkdownEditor v-model="comment" />
     </div>
   </div>

--- a/client/src/components/music/DocumentFigure.vue
+++ b/client/src/components/music/DocumentFigure.vue
@@ -1,7 +1,7 @@
 <template>
   <figure>
     <blockquote :class="blockquoteClass">
-      <p v-html="render(document.unsafe_text)"></p>
+      <MarkdownRenderer :text="document.unsafe_text" />
     </blockquote>
     <figcaption
       v-if="document.author"
@@ -24,13 +24,7 @@
 
 <script>
 import formatters from "@/mixins/formatters";
-import markdownit from "markdown-it";
-
-const md = markdownit({
-  html: true,
-  breaks: true,
-  linkify: true,
-});
+import MarkdownRenderer from "./MarkdownRenderer.vue";
 
 export default {
   props: {
@@ -39,6 +33,9 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+  components: {
+    MarkdownRenderer,
   },
   computed: {
     blockquoteClass() {
@@ -53,10 +50,5 @@ export default {
     },
   },
   mixins: [formatters],
-  methods: {
-    render(text) {
-      return md.render(text);
-    },
-  },
 };
 </script>

--- a/client/src/components/music/DocumentFigure.vue
+++ b/client/src/components/music/DocumentFigure.vue
@@ -1,7 +1,7 @@
 <template>
   <figure>
     <blockquote :class="blockquoteClass">
-      <p v-html="document.unsafe_text"></p>
+      <p v-html="render(document.unsafe_text)"></p>
     </blockquote>
     <figcaption
       v-if="document.author"
@@ -24,6 +24,13 @@
 
 <script>
 import formatters from "@/mixins/formatters";
+import markdownit from "markdown-it";
+
+const md = markdownit({
+  html: true,
+  breaks: true,
+  linkify: true,
+});
 
 export default {
   props: {
@@ -46,5 +53,10 @@ export default {
     },
   },
   mixins: [formatters],
+  methods: {
+    render(text) {
+      return md.render(text);
+    },
+  },
 };
 </script>

--- a/client/src/components/music/MarkdownEditor.vue
+++ b/client/src/components/music/MarkdownEditor.vue
@@ -1,16 +1,36 @@
 <template>
   <div class="markdown-editor d-flex flex-column bg-light p-2">
     <div class="d-flex bg-light align-items-center">
-      <button class="btn btn-light btn-sm" @click="bold" title="bold" :disabled="previewMode">
+      <button
+        class="btn btn-light btn-sm"
+        @click="bold"
+        title="bold"
+        :disabled="previewMode"
+      >
         <font-awesome-icon icon="bold" />
       </button>
-      <button class="btn btn-light btn-sm" @click="italic" title="italic" :disabled="previewMode">
+      <button
+        class="btn btn-light btn-sm"
+        @click="italic"
+        title="italic"
+        :disabled="previewMode"
+      >
         <font-awesome-icon icon="italic" />
       </button>
-      <button class="btn btn-light btn-sm" @click="underline" title="underline" :disabled="previewMode">
+      <button
+        class="btn btn-light btn-sm"
+        @click="underline"
+        title="underline"
+        :disabled="previewMode"
+      >
         <font-awesome-icon icon="underline" />
       </button>
-      <button class="btn btn-light btn-sm" @click="link" title="link" :disabled="previewMode">
+      <button
+        class="btn btn-light btn-sm"
+        @click="link"
+        title="link"
+        :disabled="previewMode"
+      >
         <font-awesome-icon icon="link" />
       </button>
     </div>
@@ -26,13 +46,15 @@
       />
       <MarkdownRenderer
         v-if="previewMode"
-        class="flex-grow-1 ps-1 pt-1"        
+        class="flex-grow-1 ps-1 pt-1"
         :text="modelValue"
       />
     </div>
     <div>
       <input id="previewCheck" type="checkbox" v-model="previewMode" />
-      <label for="previewCheck" class="ms-1 preview-label">preview formatting</label>
+      <label for="previewCheck" class="ms-1 preview-label"
+        >preview formatting</label
+      >
     </div>
   </div>
 </template>
@@ -54,7 +76,6 @@ textarea {
 .preview-label {
   font-size: 0.875em;
 }
-
 </style>
 
 <script>
@@ -91,12 +112,21 @@ export default {
       const text = this.modelValue;
       const start = ta.selectionStart;
       const end = ta.selectionEnd;
-      const before = text.substring(start - startMarker.length, start);
-      const after = text.substring(end, end + endMarker.length);
+      const selectedText = text.substring(start, end);
+      const wrappedInsideSelection =
+        selectedText.startsWith(startMarker) &&
+        selectedText.endsWith(endMarker);
+      const extendedSelection = text.substring(
+        Math.max(start - startMarker.length, 0),
+        Math.min(end + endMarker.length, text.length)
+      );
+      const wrappedOutsideSelection =
+        extendedSelection.startsWith(startMarker) &&
+        extendedSelection.endsWith(endMarker);
       let operation;
 
       ta.focus();
-      if (before === startMarker && after === endMarker) {
+      if (wrappedOutsideSelection) {
         operation = "unwrap";
         // remove markers
         ta.value =
@@ -107,6 +137,21 @@ export default {
         ta.setSelectionRange(
           start - startMarker.length,
           end - startMarker.length
+        );
+      } else if (wrappedInsideSelection) {
+        operation = "unwrap";
+        // remove markers
+        ta.value =
+          text.substring(0, start) +
+          selectedText.substring(
+            startMarker.length,
+            selectedText.length - endMarker.length
+          ) +
+          text.substring(end, text.length);
+        // select original text
+        ta.setSelectionRange(
+          start,
+          end - startMarker.length - endMarker.length
         );
       } else {
         operation = "wrap";

--- a/client/src/components/music/MarkdownEditor.vue
+++ b/client/src/components/music/MarkdownEditor.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="markdown-editor d-flex flex-column bg-light p-2">
+    <div class="d-flex bg-light align-items-center">
+      <button class="btn btn-light btn-sm" @click="bold" title="bold">
+        <font-awesome-icon icon="bold" />
+      </button>
+      <button class="btn btn-light btn-sm" @click="italic" title="italic">
+        <font-awesome-icon icon="italic" />
+      </button>
+      <button class="btn btn-light btn-sm" @click="underline" title="underline">
+        <font-awesome-icon icon="underline" />
+      </button>
+      <button class="btn btn-light btn-sm" @click="link" title="link">
+        <font-awesome-icon icon="link" />
+      </button>
+      <button
+        class="ms-auto btn btn-outline-dark btn-sm"
+        :class="{ active: inPreviewMode }"
+        @click="togglePreviewMode"
+      >
+        preview formatting
+      </button>
+    </div>
+    <div class="text-content bg-white mt-1 flex-grow-1 d-flex flex-column">
+      <textarea
+        v-if="!inPreviewMode"
+        ref="ta"
+        class="w-100 ps-1 pt-1 border-0"
+        :value="modelValue"
+        :rows="rows"
+        @input="onInput"
+        @change="onInput"
+      />
+      <MarkdownRenderer
+        v-if="inPreviewMode"
+        class="flex-grow-1 ps-1 pt-1"        
+        :text="modelValue"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.markdown-editor {
+  min-height: 7em;
+}
+
+.text-content {
+  border: 1px solid #ccc;
+}
+
+textarea {
+  resize: none;
+}
+</style>
+
+<script>
+import MarkdownRenderer from "./MarkdownRenderer.vue";
+
+const UPDATE = "update:modelValue";
+
+export default {
+  props: {
+    modelValue: {
+      type: String,
+      default: "",
+    },
+    rows: {
+      type: Number,
+      default: 2,
+    },
+  },
+  data() {
+    return {
+      previewMode: false,
+    };
+  },
+  components: {
+    MarkdownRenderer,
+  },
+  computed: {
+    inPreviewMode() {
+      return this.previewMode === true;
+    },
+  },
+  emits: [UPDATE],
+  methods: {
+    onInput(event) {
+      this.$emit(UPDATE, event.target.value);
+    },
+    togglePreviewMode() {
+      this.previewMode = !this.previewMode;
+    },
+    wrapOrUnwrap(startMarker, endMarker) {
+      const ta = this.$refs.ta;
+      const text = this.modelValue;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      const before = text.substring(start - startMarker.length, start);
+      const after = text.substring(end, end + endMarker.length);
+      let operation;
+
+      ta.focus();
+      if (before === startMarker && after === endMarker) {
+        operation = "unwrap";
+        // remove markers
+        ta.value =
+          text.substring(0, start - startMarker.length) +
+          text.substring(start, end) +
+          text.substring(end + endMarker.length, text.length);
+        // select original text
+        ta.setSelectionRange(
+          start - startMarker.length,
+          end - startMarker.length
+        );
+      } else {
+        operation = "wrap";
+        // wrap selected text
+        ta.setRangeText(startMarker + text.substring(start, end) + endMarker);
+        // select original text
+        ta.setSelectionRange(
+          start + startMarker.length,
+          start + startMarker.length + (end - start)
+        );
+      }
+
+      this.$emit(UPDATE, ta.value);
+      return operation;
+    },
+    bold() {
+      this.wrapOrUnwrap("**", "**");
+    },
+    italic() {
+      this.wrapOrUnwrap("_", "_");
+    },
+    underline() {
+      this.wrapOrUnwrap("<u>", "</u>");
+    },
+    link() {
+      const ta = this.$refs.ta;
+      const end = ta.selectionEnd;
+      const operation = this.wrapOrUnwrap("[", "](url)");
+      if (operation === "wrap") {
+        // select "url"
+        ta.setSelectionRange(end + 3, end + 6);
+      }
+    },
+  },
+};
+</script>

--- a/client/src/components/music/MarkdownEditor.vue
+++ b/client/src/components/music/MarkdownEditor.vue
@@ -1,24 +1,17 @@
 <template>
   <div class="markdown-editor d-flex flex-column bg-light p-2">
     <div class="d-flex bg-light align-items-center">
-      <button class="btn btn-light btn-sm" @click="bold" title="bold">
+      <button class="btn btn-light btn-sm" @click="bold" title="bold" :disabled="previewMode">
         <font-awesome-icon icon="bold" />
       </button>
-      <button class="btn btn-light btn-sm" @click="italic" title="italic">
+      <button class="btn btn-light btn-sm" @click="italic" title="italic" :disabled="previewMode">
         <font-awesome-icon icon="italic" />
       </button>
-      <button class="btn btn-light btn-sm" @click="underline" title="underline">
+      <button class="btn btn-light btn-sm" @click="underline" title="underline" :disabled="previewMode">
         <font-awesome-icon icon="underline" />
       </button>
-      <button class="btn btn-light btn-sm" @click="link" title="link">
+      <button class="btn btn-light btn-sm" @click="link" title="link" :disabled="previewMode">
         <font-awesome-icon icon="link" />
-      </button>
-      <button
-        class="ms-auto btn btn-outline-dark btn-sm"
-        :class="{ active: inPreviewMode }"
-        @click="togglePreviewMode"
-      >
-        preview formatting
       </button>
     </div>
     <div class="text-content bg-white mt-1 flex-grow-1 d-flex flex-column">
@@ -37,6 +30,10 @@
         :text="modelValue"
       />
     </div>
+    <div>
+      <input id="previewCheck" type="checkbox" v-model="previewMode" />
+      <label for="previewCheck" class="ms-1 preview-label">preview formatting</label>
+    </div>
   </div>
 </template>
 
@@ -47,11 +44,17 @@
 
 .text-content {
   border: 1px solid #ccc;
+  min-height: 3.5em;
 }
 
 textarea {
   resize: none;
 }
+
+.preview-label {
+  font-size: 0.875em;
+}
+
 </style>
 
 <script>
@@ -87,9 +90,6 @@ export default {
   methods: {
     onInput(event) {
       this.$emit(UPDATE, event.target.value);
-    },
-    togglePreviewMode() {
-      this.previewMode = !this.previewMode;
     },
     wrapOrUnwrap(startMarker, endMarker) {
       const ta = this.$refs.ta;

--- a/client/src/components/music/MarkdownEditor.vue
+++ b/client/src/components/music/MarkdownEditor.vue
@@ -128,16 +128,27 @@ export default {
       ta.focus();
       if (wrappedOutsideSelection) {
         operation = "unwrap";
-        // remove markers
-        ta.value =
-          text.substring(0, start - startMarker.length) +
-          text.substring(start, end) +
-          text.substring(end + endMarker.length, text.length);
-        // select original text
-        ta.setSelectionRange(
-          start - startMarker.length,
-          end - startMarker.length
-        );
+        if (start === 0 && end === text.length) {
+          // all text is wrapped
+          ta.value = text.substring(
+            startMarker.length,
+            text.length - endMarker.length
+          );
+          ta.select();
+        } else {
+          // part of the text is wrapped
+
+          // remove markers
+          ta.value =
+            text.substring(0, start - startMarker.length) +
+            text.substring(start, end) +
+            text.substring(end + endMarker.length, text.length);
+          // select original text
+          ta.setSelectionRange(
+            start - startMarker.length,
+            end - startMarker.length
+          );
+        }
       } else if (wrappedInsideSelection) {
         operation = "unwrap";
         // remove markers

--- a/client/src/components/music/MarkdownEditor.vue
+++ b/client/src/components/music/MarkdownEditor.vue
@@ -16,7 +16,7 @@
     </div>
     <div class="text-content bg-white mt-1 flex-grow-1 d-flex flex-column">
       <textarea
-        v-if="!inPreviewMode"
+        v-if="!previewMode"
         ref="ta"
         class="w-100 ps-1 pt-1 border-0"
         :value="modelValue"
@@ -25,7 +25,7 @@
         @change="onInput"
       />
       <MarkdownRenderer
-        v-if="inPreviewMode"
+        v-if="previewMode"
         class="flex-grow-1 ps-1 pt-1"        
         :text="modelValue"
       />
@@ -80,11 +80,6 @@ export default {
   },
   components: {
     MarkdownRenderer,
-  },
-  computed: {
-    inPreviewMode() {
-      return this.previewMode === true;
-    },
   },
   emits: [UPDATE],
   methods: {

--- a/client/src/components/music/MarkdownRenderer.vue
+++ b/client/src/components/music/MarkdownRenderer.vue
@@ -1,0 +1,24 @@
+<template>
+  <p v-html="render(text)"></p>
+</template>
+
+<script>
+import markdownit from "markdown-it";
+
+const md = markdownit({
+  html: true,
+  breaks: true,
+  linkify: true,
+});
+
+export default {
+  props: {
+    text: String,
+  },
+  methods: {
+    render(text) {
+      return md.render(text);
+    },
+  },
+};
+</script>

--- a/client/src/icons.js
+++ b/client/src/icons.js
@@ -58,5 +58,5 @@ library.add(
   faBold,
   faItalic,
   faUnderline,
-  faLink,
+  faLink
 );

--- a/client/src/icons.js
+++ b/client/src/icons.js
@@ -23,6 +23,10 @@ import {
   faCompactDisc,
   faClock,
   faExclamation,
+  faBold,
+  faItalic,
+  faUnderline,
+  faLink,
 } from "@fortawesome/free-solid-svg-icons";
 import { faPenToSquare as farFaPenToSquare } from "@fortawesome/free-regular-svg-icons";
 
@@ -50,5 +54,9 @@ library.add(
   faCompactDisc,
   farFaPenToSquare,
   faClock,
-  faExclamation
+  faExclamation,
+  faBold,
+  faItalic,
+  faUnderline,
+  faLink,
 );


### PR DESCRIPTION
Making a bit of a pitch here to shift from supporting HTML tags to using Markdown to format comments and reviews. It's easier to write, especially in an age of tools like Slack, Reddit, and Discord adopting its conventions. It eliminates the need for dealing with `<p>` and `<br>` tags when the renderer is configured to preserve line breaks. It also makes it easier to add formatting like lists to reviews should CHIRP folks want it.

## Details
- Shifts from using v-html tag to [markdown-it](https://github.com/markdown-it/markdown-it) to render older HTML and newer Markdown-formatted documents
- Adds a first iteration of a simple custom markdown editor (other libraries felt too heavy for the limited functionality needed)

## Some test cases to check out
- Example of an HTML-formatted review with all the DJDB-supported tags: /library/album/263133089771686903
- Example with some newer, Markdown-formatted comments: /library/album/596346758314645598