### PR TITLE
Adjust drawer and backdrop

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:1071/api
+VITE_API_URL=/api

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "VITE_API_URL=http://localhost:1071/api vite",
     "serve": "vite serve",
     "build": "vite build --emptyOutDir",
     "build:dev": "vite build --emptyOutDir --mode development",

--- a/client/src/components/OffcanvasDrawer.vue
+++ b/client/src/components/OffcanvasDrawer.vue
@@ -1,0 +1,61 @@
+<template>
+  <aside class="offcanvas offcanvas-end drawer" ref="aside">
+    <div class="offcanvas-header">
+      <slot name="header"></slot>
+    </div>
+    <div class="offcanvas-body">
+      <slot name="body"></slot>
+    </div>
+  </aside>
+</template>
+
+<script>
+import { Offcanvas } from "bootstrap";
+import { debounce } from "lodash";
+
+let debouncedResizeHandler;
+
+export default {
+  data() {
+    return {
+      drawer: undefined,
+    };
+  },
+  mounted() {
+    debouncedResizeHandler = debounce(this.onResize, 150);
+    window.addEventListener("resize", debouncedResizeHandler);
+    this.createOffcanvas();
+  },
+  beforeUnmount() {
+    this.drawer.hide();
+  },
+  unmounted() {
+    window.removeEventListener("resize", debouncedResizeHandler);
+  },
+  methods: {
+    onResize() {
+      const shown = this.drawer._isShown;
+      if (shown) {
+        this.drawer.hide();
+      }
+      this.createOffcanvas();
+      if (shown) {
+        this.drawer.show();
+      }
+    },
+    createOffcanvas() {
+      const inLargeViewport = document.documentElement.clientWidth >= 1200;
+      this.drawer = new Offcanvas(this.$refs.aside, {
+        backdrop: !inLargeViewport,
+        scroll: inLargeViewport,
+      });
+    },
+    show() {
+      this.drawer.show();
+    },
+    hide() {
+      this.drawer.hide();
+    },
+  },
+};
+</script>

--- a/client/src/components/OffcanvasDrawer.vue
+++ b/client/src/components/OffcanvasDrawer.vue
@@ -44,7 +44,7 @@ export default {
       }
     },
     createOffcanvas() {
-      const inLargeViewport = document.documentElement.clientWidth >= 1200;
+      const inLargeViewport = document.documentElement.clientWidth >= 1600;
       this.drawer = new Offcanvas(this.$refs.aside, {
         backdrop: !inLargeViewport,
         scroll: inLargeViewport,

--- a/client/src/playlist/components/AlbumPreview.vue
+++ b/client/src/playlist/components/AlbumPreview.vue
@@ -1,63 +1,66 @@
 <template>
-  <aside class="offcanvas offcanvas-end">
-    <div class="offcanvas-header">
+  <OffcanvasDrawer ref="drawer">
+    <template #header>
       <button
         type="button"
         class="btn-close"
-        data-bs-dismiss="offcanvas"
         aria-label="Close"
+        @click="hide"
       ></button>
-    </div>
-    <div class="offcanvas-body pt-0">
-      <RecordSpinner v-if="loading" />
-      <div class="row" v-if="album">
-        <div class="col-12">
-          <AlbumCard
-            :album="album"
-            :firstHeadingLevel="1"
-            :linkToAlbum="true"
-            :border="false"
-            albumArtSrcSize="xl"
-          />
-
-          <h3 class="visually-hidden">Reviews</h3>
-          <DocumentFigure
-            v-for="review in album.reviews"
-            :key="review.id"
-            :document="review"
-            class="py-3"
-          />
-
-          <div v-if="album.comments && album.comments.length">
-            <h4>Comments</h4>
-            <DocumentFigure
-              v-for="comment in album.comments"
-              :key="comment.id"
-              :document="comment"
-              :compact="true"
+    </template>
+    <template #body>
+      <div class="pt-0">
+        <RecordSpinner v-if="loading" />
+        <div class="row" v-if="album">
+          <div class="col-12">
+            <AlbumCard
+              :album="album"
+              :firstHeadingLevel="1"
+              :linkToAlbum="true"
+              :border="false"
+              albumArtSrcSize="xl"
             />
+
+            <h3 class="visually-hidden">Reviews</h3>
+            <DocumentFigure
+              v-for="review in album.reviews"
+              :key="review.id"
+              :document="review"
+              class="py-3"
+            />
+
+            <div v-if="album.comments && album.comments.length">
+              <h4>Comments</h4>
+              <DocumentFigure
+                v-for="comment in album.comments"
+                :key="comment.id"
+                :document="comment"
+                :compact="true"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </aside>
+    </template>
+  </OffcanvasDrawer>
 </template>
 
 <script>
-import { Offcanvas } from "bootstrap"; // eslint-disable-line no-unused-vars
+import OffcanvasDrawer from "@/components/OffcanvasDrawer.vue";
 import RecordSpinner from "@/components/RecordSpinner.vue";
 import AlbumCard from "@/components/music/AlbumCard.vue";
 import DocumentFigure from "@/components/music/DocumentFigure.vue";
 import { mapStores } from "pinia";
 import { useAlbumsStore } from "@/stores/albums";
+import { usePlaylistStore } from "../playlistStore";
 
 export default {
-  components: { AlbumCard, DocumentFigure, RecordSpinner },
+  components: { AlbumCard, DocumentFigure, RecordSpinner, OffcanvasDrawer },
   props: {
     album_id: String,
   },
   computed: {
-    ...mapStores(useAlbumsStore),
+    ...mapStores(useAlbumsStore, usePlaylistStore),
     album() {
       return this.albumsStore.albumById(this.album_id);
     },
@@ -70,8 +73,14 @@ export default {
   watch: {
     async album_id(newId) {
       this.loading = true;
+      this.$refs.drawer.show();
       await this.albumsStore.getAlbum(newId);
       this.loading = false;
+    },
+  },
+  methods: {
+    hide() {
+      this.$refs.drawer.hide();
     },
   },
 };

--- a/client/src/playlist/components/AlbumPreview.vue
+++ b/client/src/playlist/components/AlbumPreview.vue
@@ -73,12 +73,14 @@ export default {
   watch: {
     async album_id(newId) {
       this.loading = true;
-      this.$refs.drawer.show();
       await this.albumsStore.getAlbum(newId);
       this.loading = false;
     },
   },
   methods: {
+    show() {
+      this.$refs.drawer.show();
+    },
     hide() {
       this.$refs.drawer.hide();
     },

--- a/client/src/playlist/components/PlaylistTrack.vue
+++ b/client/src/playlist/components/PlaylistTrack.vue
@@ -12,10 +12,7 @@
             <button
               v-if="!freeform"
               class="btn btn-link-chirp-red fst-italic px-1 py-0 border-0 align-baseline"
-              data-bs-toggle="offcanvas"
-              data-bs-target="#albumPreview"
               role="button"
-              aria-controls="albumPreview"
               @click="selectAlbum"
             >
               <font-awesome-icon icon="square-caret-left" />

--- a/client/src/playlist/components/PlaylistTrack.vue
+++ b/client/src/playlist/components/PlaylistTrack.vue
@@ -74,6 +74,8 @@ import PlayedTime from "./PlayedTime.vue";
 import TagList from "@/components/music/TagList.vue";
 import Modal from "@/components/ModalDialog.vue";
 
+const PREVIEW_ALBUM = "previewAlbum";
+
 export default {
   components: { PlayedTime, TagList, Modal },
   props: {
@@ -102,9 +104,11 @@ export default {
       return !this.track.album?.album_id;
     },
   },
+  emits: [PREVIEW_ALBUM],
   methods: {
     selectAlbum() {
       this.playlistStore.selectAlbum(this.track.album.album_id.value);
+      this.$emit(PREVIEW_ALBUM);
     },
     showConfirmationModal() {
       this.$refs.deleteModal.show();

--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -25,7 +25,7 @@
 
     <OffcanvasDrawer id="spot" ref="drawer">
       <template #header>
-        <div class="d-flex align-items-center">
+        <div class="w-100 d-flex align-items-center">
           <h5 class="offcanvas-title flex-grow-1" id="offcanvasLabel">
             {{ spotHeading(selected) }}
           </h5>

--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -126,6 +126,9 @@ export default {
       }
     },
   },
+  created() {
+    this.trafficLogStore.pollForEntries();
+  },
   methods: {
     time(entry) {
       let hour;

--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -23,67 +23,67 @@
       </button>
     </ul>
 
-    <aside id="spot" ref="spot" class="offcanvas offcanvas-end drawer">
-      <div class="offcanvas-header d-flex align-items-center">
-        <h5 class="offcanvas-title flex-grow-1" id="offcanvasLabel">
-          {{ spotHeading(selected) }}
-        </h5>
-        <span v-if="selectedGroup" class="h5 mb-0 me-2">
-          {{ ordinal }} of {{ selectedGroup.length }} spots
-        </span>
-      </div>
-      <div class="offcanvas-body fs-3 fs-md-1">
-        <TrafficLogActions
-          :previous="previousInGroup"
-          :next="nextInGroup"
-          :has-been-read="hasBeenRead(selected)"
-          @close="close"
-          @previous="previous"
-          @next="next"
-          @mark-as-read="markAsRead"
-        ></TrafficLogActions>
-        <p class="mt-2 mb-5">{{ selected?.spot_copy.body }}</p>
-        <TrafficLogActions
-          :previous="previousInGroup"
-          :next="nextInGroup"
-          :has-been-read="hasBeenRead(selected)"
-          @close="close"
-          @previous="previous"
-          @next="next"
-          @mark-as-read="markAsRead"
-        ></TrafficLogActions>
-        <div class="font-sans fs-6">
-          <div v-if="previousInGroup">
-            Previous spot: {{ spotHeading(previousInGroup) }} ({{
-              readLabel(previousInGroup)
-            }})
-          </div>
-          <div v-if="nextInGroup">
-            Next spot: {{ spotHeading(nextInGroup) }} ({{
-              readLabel(nextInGroup)
-            }})
+    <OffcanvasDrawer id="spot" ref="drawer">
+      <template #header>
+        <div class="d-flex align-items-center">
+          <h5 class="offcanvas-title flex-grow-1" id="offcanvasLabel">
+            {{ spotHeading(selected) }}
+          </h5>
+          <span v-if="selectedGroup" class="h5 mb-0 me-2">
+            {{ ordinal }} of {{ selectedGroup.length }} spots
+          </span>
+        </div>
+      </template>
+      <template #body>
+        <div class="offcanvas-body fs-3 fs-md-1">
+          <TrafficLogActions
+            :previous="previousInGroup"
+            :next="nextInGroup"
+            :has-been-read="hasBeenRead(selected)"
+            @close="hide"
+            @previous="previous"
+            @next="next"
+            @mark-as-read="markAsRead"
+          ></TrafficLogActions>
+          <p class="mt-2 mb-5">{{ selected?.spot_copy.body }}</p>
+          <TrafficLogActions
+            :previous="previousInGroup"
+            :next="nextInGroup"
+            :has-been-read="hasBeenRead(selected)"
+            @close="hide"
+            @previous="previous"
+            @next="next"
+            @mark-as-read="markAsRead"
+          ></TrafficLogActions>
+          <div class="font-sans fs-6">
+            <div v-if="previousInGroup">
+              Previous spot: {{ spotHeading(previousInGroup) }} ({{
+                readLabel(previousInGroup)
+              }})
+            </div>
+            <div v-if="nextInGroup">
+              Next spot: {{ spotHeading(nextInGroup) }} ({{
+                readLabel(nextInGroup)
+              }})
+            </div>
           </div>
         </div>
-      </div>
-    </aside>
+      </template>
+    </OffcanvasDrawer>
   </div>
 </template>
 
 <script>
-import { Offcanvas } from "bootstrap"; // eslint-disable-line no-unused-vars
 import { mapStores } from "pinia";
 import { useTrafficLogStore } from "../trafficLogStore";
 import TrafficLogActions from "./TrafficLogActions.vue";
 import RecordSpinner from "@/components/RecordSpinner.vue";
-import { debounce } from "lodash";
-
-let debouncedResizeHandler;
+import OffcanvasDrawer from "@/components/OffcanvasDrawer.vue";
 
 export default {
-  components: { TrafficLogActions, RecordSpinner },
+  components: { TrafficLogActions, RecordSpinner, OffcanvasDrawer },
   data() {
     return {
-      drawer: undefined,
       selected: null,
     };
   },
@@ -126,38 +126,7 @@ export default {
       }
     },
   },
-  created() {
-    this.trafficLogStore.pollForEntries();
-  },
-  mounted() {
-    debouncedResizeHandler = debounce(this.onResize, 150);
-    window.addEventListener("resize", debouncedResizeHandler);
-    this.createOffcanvas();
-  },
-  beforeUnmount() {
-    this.drawer.hide();
-  },
-  unmounted() {
-    window.removeEventListener("resize", debouncedResizeHandler);
-  },
   methods: {
-    onResize() {
-      const shown = this.drawer._isShown;
-      if (shown) {
-        this.drawer.hide();
-      }
-      this.createOffcanvas();
-      if (shown) {
-        this.drawer.show();
-      }
-    },
-    createOffcanvas() {
-      const inLargeViewport = document.documentElement.clientWidth >= 1200;
-      this.drawer = new Offcanvas(this.$refs.spot, {
-        backdrop: !inLargeViewport,
-        scroll: inLargeViewport,
-      });
-    },
     time(entry) {
       let hour;
       if (entry.hour > 12) {
@@ -180,8 +149,8 @@ export default {
     select(entry) {
       this.selected = entry;
     },
-    close() {
-      this.drawer.hide();
+    hide() {
+      this.$refs.drawer.hide();
     },
     previous() {
       this.selected = this.previousInGroup;
@@ -194,7 +163,7 @@ export default {
       if (this.nextInGroup) {
         this.next();
       } else {
-        this.close();
+        this.hide();
       }
     },
     hasBeenRead(entry) {

--- a/client/src/playlist/components/TrafficLog.vue
+++ b/client/src/playlist/components/TrafficLog.vue
@@ -75,6 +75,9 @@ import { mapStores } from "pinia";
 import { useTrafficLogStore } from "../trafficLogStore";
 import TrafficLogActions from "./TrafficLogActions.vue";
 import RecordSpinner from "@/components/RecordSpinner.vue";
+import { debounce } from "lodash";
+
+let debouncedResizeHandler;
 
 export default {
   components: { TrafficLogActions, RecordSpinner },
@@ -127,9 +130,34 @@ export default {
     this.trafficLogStore.pollForEntries();
   },
   mounted() {
-    this.drawer = new Offcanvas(this.$refs.spot);
+    debouncedResizeHandler = debounce(this.onResize, 150);
+    window.addEventListener("resize", debouncedResizeHandler);
+    this.createOffcanvas();
+  },
+  beforeUnmount() {
+    this.drawer.hide();
+  },
+  unmounted() {
+    window.removeEventListener("resize", debouncedResizeHandler);
   },
   methods: {
+    onResize() {
+      const shown = this.drawer._isShown;
+      if (shown) {
+        this.drawer.hide();
+      }
+      this.createOffcanvas();
+      if (shown) {
+        this.drawer.show();
+      }
+    },
+    createOffcanvas() {
+      const inLargeViewport = document.documentElement.clientWidth >= 1200;
+      this.drawer = new Offcanvas(this.$refs.spot, {
+        backdrop: !inLargeViewport,
+        scroll: inLargeViewport,
+      });
+    },
     time(entry) {
       let hour;
       if (entry.hour > 12) {

--- a/client/src/playlist/views/PlaylistView.vue
+++ b/client/src/playlist/views/PlaylistView.vue
@@ -55,6 +55,7 @@
                 :is="getComponent(event)"
                 :track="event"
                 class="py-2"
+                @preview-album="onPreviewAlbum"
               />
             </li>
           </ol>
@@ -90,7 +91,7 @@
     </nav>
 
     <AddTrackModal ref="addTrackModal" />
-    <AlbumPreview id="albumPreview" :album_id="selectedAlbumId" />
+    <AlbumPreview ref="albumPreview" :album_id="selectedAlbumId" />
   </div>
 </template>
 
@@ -200,6 +201,9 @@ export default {
           this.sectionInView = PLAYLIST;
         }
       }
+    },
+    onPreviewAlbum() {
+      this.$refs.albumPreview.show();
     },
   },
 };

--- a/client/src/playlist/views/PlaylistView.vue
+++ b/client/src/playlist/views/PlaylistView.vue
@@ -90,11 +90,7 @@
     </nav>
 
     <AddTrackModal ref="addTrackModal" />
-    <AlbumPreview
-      id="albumPreview"
-      class="drawer"
-      :album_id="selectedAlbumId"
-    />
+    <AlbumPreview id="albumPreview" :album_id="selectedAlbumId" />
   </div>
 </template>
 

--- a/client/src/scss/styles.scss
+++ b/client/src/scss/styles.scss
@@ -190,14 +190,14 @@ a.btn-link-light:hover {
 }
 
 .drawer {
-  width: 100% !important;
+  width: 90% !important;
 }
 
 .offcanvas-backdrop.show {
   opacity: 0.1;
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 768px) {
   .drawer {
     width: 750px !important;
   }


### PR DESCRIPTION
In the Playlist:
- Don't create a backdrop behind the traffic log and album preview (i.e., allow clicking) and allow scrolling in larger viewports (>=1600px)
- Create the backdrop and prevent scrolling on smaller viewports (<1600px)
- Adjust gracefully when the browser is resized
- Rollback the previous changes and make the drawer's width only 90% of small viewports instead of 100%