### PR TITLE
maintain recent plays list to support showing recent artist/album plays

### DIFF
--- a/client/src/components/music/RecentlyPlayedAlert.vue
+++ b/client/src/components/music/RecentlyPlayedAlert.vue
@@ -6,7 +6,7 @@
     role="alert"
   >
     <font-awesome-icon icon="fa-circle-pause" fade class="slow-fade" />
-    played by {{ dj }} at {{ time }}
+    {{ object_word }}played by {{ dj }} at {{ time }}
   </div>
 </template>
 
@@ -44,6 +44,17 @@ export default {
     ...mapStores(usePlaylistStore),
     recentPlay() {
       return this.playlistStore.recentPlay(this.album);
+    },
+    object_word() {
+      let action = "";
+      if (this.album?.id === this.recentPlay.album.__key?.name) {
+        action = "album ";
+      } else if (
+        this.album.album_artist?.id === this.recentPlay.album.album_artist?.name
+      ) {
+        action = "artist ";
+      }
+      return action;
     },
     dj() {
       let name = "";

--- a/client/src/playlist/views/PlaylistView.vue
+++ b/client/src/playlist/views/PlaylistView.vue
@@ -160,6 +160,7 @@ export default {
   },
   created: async function () {
     this.update();
+    this.playlistStore.pollRecentPlays();
     this.playlistStore.pollRotationPlays();
   },
   mounted() {

--- a/client/src/views/music/MusicView.vue
+++ b/client/src/views/music/MusicView.vue
@@ -17,6 +17,7 @@ export default {
   },
   created() {
     this.playlistStore.pollRotationPlays();
+    this.playlistStore.pollRecentPlays();
   },
 };
 </script>


### PR DESCRIPTION
Using the same logic as rotationPlays in client/src/playlist/playlistStore.js maintain a recentPlays as well. Use this in client/src/components/music/RecentlyPlayedAlert.vue to alert if an album or artist has been played recently. These changes are visible in any album list as well as in the details for an album.

<img width="972" height="1346" alt="image" src="https://github.com/user-attachments/assets/15095606-ec0a-4310-b1e0-d8138578e586" />
