### PR TITLE
Label spot copy without dates as started

### DIFF
--- a/client/src/traffic-log/components/SpotCopyItem.vue
+++ b/client/src/traffic-log/components/SpotCopyItem.vue
@@ -64,10 +64,13 @@ export default {
       return this.copy.name || this.copy.body;
     },
     started() {
-      return copyStarted(this.copy.start_on);
+      return copyStarted(this.copy.start_on) || this.noDates;
     },
     expired() {
       return copyExpired(this.copy.expire_on);
+    },
+    noDates() {
+      return !this.copy.start_on && !this.copy.expire_on;
     },
     badgeLabel() {
       if (this.expired) {

--- a/client/src/traffic-log/components/SpotCopyList.vue
+++ b/client/src/traffic-log/components/SpotCopyList.vue
@@ -82,7 +82,9 @@ export default {
           return this.spot.copy.filter((copy) => copyExpired(copy.expire_on));
         case "started":
           return this.spot.copy.filter(
-            (copy) => copyStarted(copy.start_on) && !copyExpired(copy.expire_on)
+            (copy) =>
+              (!copy.start_on && !copy.expire_on) ||
+              (copyStarted(copy.start_on) && !copyExpired(copy.expire_on))
           );
         case "notStarted":
           return this.spot.copy.filter(


### PR DESCRIPTION
Update label and styling to match the back end logic for determining which copy has started and should be in the traffic log.

Slack thread: https://chirpdev.slack.com/archives/C01GW3BRV5H/p1758580846691479?thread_ts=1758384136.144619&cid=C01GW3BRV5H

